### PR TITLE
Implement logging multiple hyperparameters at once

### DIFF
--- a/verta/tests/test_workflow.py
+++ b/verta/tests/test_workflow.py
@@ -39,7 +39,7 @@ def test_datasets(run):
     assert run.get_datasets() == datasets
 
 
-def test_hyperparameters(run):
+def test_hyperparameters1(run):
     hyperparameters = {
         utils.gen_str(): utils.gen_str(),
         utils.gen_str(): utils.gen_int(),
@@ -48,6 +48,48 @@ def test_hyperparameters(run):
 
     for key, val in hyperparameters.items():
         run.log_hyperparameter(key, val)
+
+    with pytest.raises(KeyError):
+        run.get_hyperparameter(utils.gen_str())
+
+    for key, val in hyperparameters.items():
+        assert run.get_hyperparameter(key) == val
+
+    assert run.get_hyperparameters() == hyperparameters
+
+
+def test_hyperparameters2(run):
+    hyperparameters = {
+        utils.gen_str(): utils.gen_str(),
+        utils.gen_str(): utils.gen_int(),
+        utils.gen_str(): utils.gen_float(),
+    }
+
+    with pytest.raises(ValueError):
+        run.log_hyperparameters(hyperparameters, **hyperparameters)
+
+    run.log_hyperparameters(hyperparameters)
+
+    with pytest.raises(KeyError):
+        run.get_hyperparameter(utils.gen_str())
+
+    for key, val in hyperparameters.items():
+        assert run.get_hyperparameter(key) == val
+
+    assert run.get_hyperparameters() == hyperparameters
+
+
+def test_hyperparameters3(run):
+    hyperparameters = {
+        utils.gen_str(): utils.gen_str(),
+        utils.gen_str(): utils.gen_int(),
+        utils.gen_str(): utils.gen_float(),
+    }
+
+    with pytest.raises(ValueError):
+        run.log_hyperparameters(hyperparameters, **hyperparameters)
+
+    run.log_hyperparameters(**hyperparameters)
 
     with pytest.raises(KeyError):
         run.get_hyperparameter(utils.gen_str())


### PR DESCRIPTION
This is **not** the final version of this function. Ideally, logging multiple hyperparameters would occur with one RPC (see [this issue](https://github.com/VertaAI/mdb-v2-backend/issues/38)), but this function should exist anyway (it'll make the user guide a bit cleaner).