### PR TITLE
Change set_* exceptions to warnings

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import utils
 
 from verta import ModelDBClient
+from verta.modeldbclient import Project, Experiment, ExperimentRun
 
 
 HOST_ENV_VAR = "MODELDB_HOST"
@@ -50,15 +51,32 @@ def output_path():
 @pytest.fixture
 def client(host, port, email, dev_key):
     client = ModelDBClient(host, port, email, dev_key)
-
     yield client
-
     if client.proj is not None:
         utils.delete_project(client.proj._id, client)
 
 
 @pytest.fixture
-def experiment_run(client):
-    client.set_project()
-    client.set_experiment()
-    return client.set_experiment_run()
+def project(client):
+    proj = Project._create(client._auth, client._socket,
+                           Project._generate_default_name())
+    yield proj
+    utils.delete_project(proj._id, client)
+
+
+@pytest.fixture
+def experiment(project, client):
+    expt = Experiment._create(client._auth, client._socket,
+                              project._id,
+                              Experiment._generate_default_name())
+    yield expt
+    utils.delete_experiment(expt._id, client)
+
+
+@pytest.fixture
+def experiment_run(project, experiment, client):
+    expt_run = ExperimentRun._create(client._auth, client._socket,
+                                     project._id, experiment._id,
+                                     ExperimentRun._generate_default_name())
+    yield expt_run
+    utils.delete_experiment_run(expt_run._id, client)

--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -58,7 +58,7 @@ def client(host, port, email, dev_key):
 
 
 @pytest.fixture
-def run(client):
+def experiment_run(client):
     client.set_project()
     client.set_experiment()
     return client.set_experiment_run()

--- a/verta/tests/test_entities.py
+++ b/verta/tests/test_entities.py
@@ -1,0 +1,45 @@
+import itertools
+
+import pytest
+import utils
+
+
+KWARGS = {
+    'desc': [None, "A test."],
+    'tags': [None, ['test']],
+    'attrs': [None, {'is_test': True}],
+}
+KWARGS_COMBOS = [dict(zip(KWARGS.keys(), values))
+                 for values
+                 in itertools.product(*KWARGS.values())
+                 if values.count(None) != len(values)]
+
+
+class TestProject:
+    def test_set_project_warning(self, client):
+        proj = client.set_project()
+
+        for kwargs in KWARGS_COMBOS:
+            with pytest.warns(UserWarning):
+                client.set_project(proj.name, **kwargs)
+
+
+class TestExperiment:
+    def test_set_experiment_warning(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        for kwargs in KWARGS_COMBOS:
+            with pytest.warns(UserWarning):
+                client.set_experiment(expt.name, **kwargs)
+
+
+class TestExperimentRun:
+    def test_set_experiment_run_warning(self, client):
+        client.set_project()
+        client.set_experiment()
+        expt_run = client.set_experiment_run()
+
+        for kwargs in KWARGS_COMBOS:
+            with pytest.warns(UserWarning):
+                client.set_experiment_run(expt_run.name, **kwargs)

--- a/verta/tests/test_workflow.py
+++ b/verta/tests/test_workflow.py
@@ -9,46 +9,46 @@ class TestHyperparameters:
         utils.gen_str(): utils.gen_float(),
     }
 
-    def test_single(self, run):
+    def test_single(self, experiment_run):
         for key, val in self.hyperparameters.items():
-            run.log_hyperparameter(key, val)
+            experiment_run.log_hyperparameter(key, val)
 
         with pytest.raises(KeyError):
-            run.get_hyperparameter(utils.gen_str())
+            experiment_run.get_hyperparameter(utils.gen_str())
 
         for key, val in self.hyperparameters.items():
-            assert run.get_hyperparameter(key) == val
+            assert experiment_run.get_hyperparameter(key) == val
 
-        assert run.get_hyperparameters() == self.hyperparameters
+        assert experiment_run.get_hyperparameters() == self.hyperparameters
 
-    def test_dict(self, run):
+    def test_dict(self, experiment_run):
         with pytest.raises(ValueError):
-            run.log_hyperparameters(self.hyperparameters, **self.hyperparameters)
+            experiment_run.log_hyperparameters(self.hyperparameters, **self.hyperparameters)
 
-        run.log_hyperparameters(self.hyperparameters)
-
-        with pytest.raises(KeyError):
-            run.get_hyperparameter(utils.gen_str())
-
-        for key, val in self.hyperparameters.items():
-            assert run.get_hyperparameter(key) == val
-
-        assert run.get_hyperparameters() == self.hyperparameters
-
-    def test_unpack(self, run):
-        run.log_hyperparameters(**self.hyperparameters)
+        experiment_run.log_hyperparameters(self.hyperparameters)
 
         with pytest.raises(KeyError):
-            run.get_hyperparameter(utils.gen_str())
+            experiment_run.get_hyperparameter(utils.gen_str())
 
         for key, val in self.hyperparameters.items():
-            assert run.get_hyperparameter(key) == val
+            assert experiment_run.get_hyperparameter(key) == val
 
-        assert run.get_hyperparameters() == self.hyperparameters
+        assert experiment_run.get_hyperparameters() == self.hyperparameters
+
+    def test_unpack(self, experiment_run):
+        experiment_run.log_hyperparameters(**self.hyperparameters)
+
+        with pytest.raises(KeyError):
+            experiment_run.get_hyperparameter(utils.gen_str())
+
+        for key, val in self.hyperparameters.items():
+            assert experiment_run.get_hyperparameter(key) == val
+
+        assert experiment_run.get_hyperparameters() == self.hyperparameters
 
 
 class TestArtifacts:
-    def test_datasets(self, run, output_path):
+    def test_datasets(self, experiment_run, output_path):
         # values represent literal artifacts
         datasets = {
             utils.gen_str(): utils.gen_str(),
@@ -57,38 +57,38 @@ class TestArtifacts:
 
         # log
         for key, val in datasets.items():
-            run.log_dataset(key, output_path.format(key), val)
+            experiment_run.log_dataset(key, output_path.format(key), val)
 
         # try get nonexistent key
         with pytest.raises(KeyError):
-            run.get_dataset(utils.gen_str())
+            experiment_run.get_dataset(utils.gen_str())
 
         # get path
         for key in datasets.keys():
-            assert run.get_dataset(key) == output_path.format(key)
+            assert experiment_run.get_dataset(key) == output_path.format(key)
 
         # load obj
         for key, val in datasets.items():
-            assert run.get_dataset(key, load=True) == val
+            assert experiment_run.get_dataset(key, load=True) == val
 
         # get all paths
-        assert run.get_datasets() == dict(zip(datasets.keys(),
+        assert experiment_run.get_datasets() == dict(zip(datasets.keys(),
                                               [output_path.format(key) for key in datasets]))
 
         # load all objs
-        assert run.get_datasets(load=True) == datasets
+        assert experiment_run.get_datasets(load=True) == datasets
 
         # try load nonlocal obj
         new_key = utils.gen_str()
         datasets[new_key] = output_path.format(new_key)
-        run.log_dataset(new_key, datasets[new_key])
+        experiment_run.log_dataset(new_key, datasets[new_key])
         with pytest.raises(FileNotFoundError):
-            run.get_dataset(new_key, load=True)
+            experiment_run.get_dataset(new_key, load=True)
         with pytest.raises(FileNotFoundError):
-            run.get_datasets(load=True, errors='raise')
-        assert run.get_datasets(load=True, errors='ignore') == datasets
+            experiment_run.get_datasets(load=True, errors='raise')
+        assert experiment_run.get_datasets(load=True, errors='ignore') == datasets
 
-    def test_images(self, run, output_path):
+    def test_images(self, experiment_run, output_path):
         # values represent literal artifacts
         images = {
             utils.gen_str(): utils.gen_str(),
@@ -97,38 +97,38 @@ class TestArtifacts:
 
         # log
         for key, val in images.items():
-            run.log_image(key, output_path.format(key), val)
+            experiment_run.log_image(key, output_path.format(key), val)
 
         # try get nonexistent key
         with pytest.raises(KeyError):
-            run.get_image(utils.gen_str())
+            experiment_run.get_image(utils.gen_str())
 
         # get path
         for key in images.keys():
-            assert run.get_image(key) == output_path.format(key)
+            assert experiment_run.get_image(key) == output_path.format(key)
 
         # load obj
         for key, val in images.items():
-            assert run.get_image(key, load=True) == val
+            assert experiment_run.get_image(key, load=True) == val
 
         # get all paths
-        assert run.get_images() == dict(zip(images.keys(),
+        assert experiment_run.get_images() == dict(zip(images.keys(),
                                             [output_path.format(key) for key in images]))
 
         # load all objs
-        assert run.get_images(load=True) == images
+        assert experiment_run.get_images(load=True) == images
 
         # try load nonlocal obj
         new_key = utils.gen_str()
         images[new_key] = output_path.format(new_key)
-        run.log_image(new_key, images[new_key])
+        experiment_run.log_image(new_key, images[new_key])
         with pytest.raises(FileNotFoundError):
-            run.get_image(new_key, load=True)
+            experiment_run.get_image(new_key, load=True)
         with pytest.raises(FileNotFoundError):
-            run.get_images(load=True, errors='raise')
-        assert run.get_images(load=True, errors='ignore') == images
+            experiment_run.get_images(load=True, errors='raise')
+        assert experiment_run.get_images(load=True, errors='ignore') == images
 
-    def test_models(self, run, output_path):
+    def test_models(self, experiment_run, output_path):
         # values represent literal artifacts
         models = {
             utils.gen_str(): utils.gen_str(),
@@ -137,39 +137,39 @@ class TestArtifacts:
 
         # log
         for key, val in models.items():
-            run.log_model(key, output_path.format(key), val)
+            experiment_run.log_model(key, output_path.format(key), val)
 
         # try get nonexistent key
         with pytest.raises(KeyError):
-            run.get_model(utils.gen_str())
+            experiment_run.get_model(utils.gen_str())
 
         # get path
         for key in models.keys():
-            assert run.get_model(key) == output_path.format(key)
+            assert experiment_run.get_model(key) == output_path.format(key)
 
         # load obj
         for key, val in models.items():
-            assert run.get_model(key, load=True) == val
+            assert experiment_run.get_model(key, load=True) == val
 
         # get all paths
-        assert run.get_models() == dict(zip(models.keys(),
+        assert experiment_run.get_models() == dict(zip(models.keys(),
                                             [output_path.format(key) for key in models]))
 
         # load all objs
-        assert run.get_models(load=True) == models
+        assert experiment_run.get_models(load=True) == models
 
         # try load nonlocal obj
         new_key = utils.gen_str()
         models[new_key] = output_path.format(new_key)
-        run.log_model(new_key, models[new_key])
+        experiment_run.log_model(new_key, models[new_key])
         with pytest.raises(FileNotFoundError):
-            run.get_model(new_key, load=True)
+            experiment_run.get_model(new_key, load=True)
         with pytest.raises(FileNotFoundError):
-            run.get_models(load=True, errors='raise')
-        assert run.get_models(load=True, errors='ignore') == models
+            experiment_run.get_models(load=True, errors='raise')
+        assert experiment_run.get_models(load=True, errors='ignore') == models
 
 
-def test_attributes(run):
+def test_attributes(experiment_run):
     attributes = {
         utils.gen_str(): utils.gen_str(),
         utils.gen_str(): utils.gen_int(),
@@ -177,18 +177,18 @@ def test_attributes(run):
     }
 
     for key, val in attributes.items():
-        run.log_attribute(key, val)
+        experiment_run.log_attribute(key, val)
 
     with pytest.raises(KeyError):
-        run.get_attribute(utils.gen_str())
+        experiment_run.get_attribute(utils.gen_str())
 
     for key, val in attributes.items():
-        assert run.get_attribute(key) == val
+        assert experiment_run.get_attribute(key) == val
 
-    assert run.get_attributes() == attributes
+    assert experiment_run.get_attributes() == attributes
 
 
-def test_metrics(run):
+def test_metrics(experiment_run):
     metrics = {
         utils.gen_str(): utils.gen_str(),
         utils.gen_str(): utils.gen_int(),
@@ -196,18 +196,18 @@ def test_metrics(run):
     }
 
     for key, val in metrics.items():
-        run.log_metric(key, val)
+        experiment_run.log_metric(key, val)
 
     with pytest.raises(KeyError):
-        run.get_metric(utils.gen_str())
+        experiment_run.get_metric(utils.gen_str())
 
     for key, val in metrics.items():
-        assert run.get_metric(key) == val
+        assert experiment_run.get_metric(key) == val
 
-    assert run.get_metrics() == metrics
+    assert experiment_run.get_metrics() == metrics
 
 
-def test_observations(run):
+def test_observations(experiment_run):
     observations = {
         utils.gen_str(): [utils.gen_str(), utils.gen_str()],
         utils.gen_str(): [utils.gen_int(), utils.gen_int()],
@@ -216,12 +216,12 @@ def test_observations(run):
 
     for key, vals in observations.items():
         for val in vals:
-            run.log_observation(key, val)
+            experiment_run.log_observation(key, val)
 
     with pytest.raises(KeyError):
-        run.get_observation(utils.gen_str())
+        experiment_run.get_observation(utils.gen_str())
 
     for key, val in observations.items():
-        assert run.get_observation(key) == val
+        assert experiment_run.get_observation(key) == val
 
-    assert run.get_observations() == observations
+    assert experiment_run.get_observations() == observations

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -2,6 +2,7 @@ import re
 import ast
 import time
 from urllib.parse import urlparse
+import warnings
 
 import requests
 
@@ -263,8 +264,8 @@ class Project:
             except requests.HTTPError as e:
                 if e.response.status_code == 409:  # already exists
                     if any(param is not None for param in (desc, tags, attrs)):
-                        raise ValueError("Project with name {} already exists;"
-                                         " cannot initialize `desc`, `tags`, or `attrs`".format(proj_name))
+                        warnings.warn("Project with name {} already exists;"
+                                      " cannot initialize `desc`, `tags`, or `attrs`".format(proj_name))
                     proj = Project._get(auth, socket, proj_name)
                     print("set existing Project: {}".format(proj.name))
                 else:
@@ -400,8 +401,8 @@ class Experiment:
             except requests.HTTPError as e:
                 if e.response.status_code == 409:  # already exists
                     if any(param is not None for param in (desc, tags, attrs)):
-                        raise ValueError("Experiment with name {} already exists;"
-                                         " cannot initialize `desc`, `tags`, or `attrs`".format(expt_name))
+                        warnings.warn("Experiment with name {} already exists;"
+                                      " cannot initialize `desc`, `tags`, or `attrs`".format(expt_name))
                     expt = Experiment._get(auth, socket, proj_id, expt_name)
                     print("set existing Experiment: {}".format(expt.name))
                 else:
@@ -827,8 +828,8 @@ class ExperimentRun:
             except requests.HTTPError as e:
                 if e.response.status_code == 409:  # already exists
                     if any(param is not None for param in (desc, tags, attrs)):
-                        raise ValueError("ExperimentRun with name {} already exists;"
-                                         " cannot initialize `desc`, `tags`, or `attrs`".format(expt_run_name))
+                        warnings.warn("ExperimentRun with name {} already exists;"
+                                      " cannot initialize `desc`, `tags`, or `attrs`".format(expt_run_name))
                     expt_run = ExperimentRun._get(auth, socket, proj_id, expt_id, expt_run_name)
                     print("set existing ExperimentRun: {}".format(expt_run.name))
                 else:


### PR DESCRIPTION
Previously, the user would encounter an exception when attempting to set a description, tags, and/or attributes using `set_project()`, `set_experiment()`, and `set_experiment_run()` when an entity by the specified name already exists.

This is because `set_*()` shouldn't be used to write entity fields, and also because it seems a user would only do this if they assumed the entity didn't exist to begin with.

The exception has been changed to a warning so as to not halt execution of the workflow.

A flag to enable force-overwriting description, tags, and/or attributes through the `set_*()` function will be added in the future, once I actually implement functions to do those.