### PR TITLE
Enable Python2 compatibility

### DIFF
--- a/verta/requirements.txt
+++ b/verta/requirements.txt
@@ -4,6 +4,7 @@ twine~=1.13
 wheel~=0.32
 
 # unit testing
+six~=1.11
 pytest~=4.3
 
 # documentation

--- a/verta/setup.py
+++ b/verta/setup.py
@@ -17,7 +17,7 @@ setup(
         "verta",
         "verta._protos.public.modeldb",
     ],
-    python_requires=">= 3.5, < 3.8",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
         "googleapis-common-protos~=1.5",
         "grpcio~=1.16",

--- a/verta/setup.py
+++ b/verta/setup.py
@@ -25,5 +25,6 @@ setup(
         "pathlib2~=2.1",
         "protobuf~=3.6",
         "requests~=2.21",
+        "six~=1.12",
     ],
 )

--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -1,10 +1,10 @@
 import os
 import shutil
 
+from verta import ModelDBClient
+
 import pytest
 import utils
-
-from verta import ModelDBClient
 
 
 HOST_ENV_VAR = "MODELDB_HOST"

--- a/verta/tests/test_entities.py
+++ b/verta/tests/test_entities.py
@@ -34,6 +34,27 @@ class TestExperiment:
                 client.set_experiment(expt.name, **kwargs)
 
 
+class TestExperimentRuns:
+    def test_magic_methods(self, client):
+        client.set_project()
+        expt1 = client.set_experiment()
+
+        # __getitem__
+        expt1_run_ids = [client.set_experiment_run()._id for _ in range(12)]
+        for expt_run_id, expt_run in zip(expt1_run_ids, expt1.expt_runs):
+            assert expt_run_id == expt_run._id
+
+        # __len__
+        assert len(expt1_run_ids) == len(expt1.expt_runs)
+
+        # __add__
+        expt2 = client.set_experiment()
+        expt2_run_ids = [client.set_experiment_run()._id for _ in range(12)]
+        for expt_run_id, expt_run in zip(expt1_run_ids + expt2_run_ids,
+                                         expt1.expt_runs + expt2.expt_runs):
+            assert expt_run_id == expt_run._id
+
+
 class TestExperimentRun:
     def test_set_experiment_run_warning(self, client):
         client.set_project()

--- a/verta/tests/test_entities.py
+++ b/verta/tests/test_entities.py
@@ -1,4 +1,5 @@
 import itertools
+import random
 
 import pytest
 import utils
@@ -35,25 +36,39 @@ class TestExperiment:
 
 
 class TestExperimentRuns:
-    def test_magic_methods(self, client):
+    def test_magic_getitem(self, client):
         client.set_project()
-        expt1 = client.set_experiment()
+        expt = client.set_experiment()
+        expt_run_ids = []
 
-        # __getitem__
-        expt1_run_ids = [client.set_experiment_run()._id for _ in range(12)]
-        for expt_run_id, expt_run in zip(expt1_run_ids, expt1.expt_runs):
+        expt_run_ids.extend(client.set_experiment_run()._id for _ in range(12))
+        for expt_run_id, expt_run in zip(expt_run_ids, expt.expt_runs):
             assert expt_run_id == expt_run._id
 
-        # __len__
-        assert len(expt1_run_ids) == len(expt1.expt_runs)
+        expt_run_ids.extend(client.set_experiment_run()._id for _ in range(12))
+        for expt_run_id, expt_run in zip(expt_run_ids, expt.expt_runs):
+            assert expt_run_id == expt_run._id
 
-        # __add__
+    def test_magic_len(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+        expt_run_ids = [client.set_experiment_run()._id for _ in range(12)]
+
+        assert len(expt_run_ids) == len(expt.expt_runs)
+
+    def test_magic_add(self, client):
+        client.set_project()
+        expt1 = client.set_experiment()
+        expt1_run_ids = [client.set_experiment_run()._id for _ in range(12)]
         expt2 = client.set_experiment()
         expt2_run_ids = [client.set_experiment_run()._id for _ in range(12)]
+
+        # simple concatenation
         for expt_run_id, expt_run in zip(expt1_run_ids + expt2_run_ids,
                                          expt1.expt_runs + expt2.expt_runs):
             assert expt_run_id == expt_run._id
 
+<<<<<<< HEAD
 
 class TestExperimentRun:
     def test_set_experiment_run_warning(self, client):
@@ -64,3 +79,92 @@ class TestExperimentRun:
         for kwargs in KWARGS_COMBOS:
             with pytest.warns(UserWarning):
                 client.set_experiment_run(expt_run.name, **kwargs)
+=======
+        # ignore duplicates
+        woven_run_ids = [id_ for pair in zip(expt1_run_ids, expt2_run_ids) for id_ in pair]
+        woven_expt_runs = expt1.expt_runs.__class__(client._auth, client._socket, woven_run_ids)
+        for expt_run_id, expt_run in zip(expt1_run_ids + expt2_run_ids,
+                                         expt1.expt_runs + woven_expt_runs):
+            assert expt_run_id == expt_run._id
+
+    def test_find(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        metric_vals = random.sample(range(36), 12)
+        hyperparam_vals = random.sample(range(36), 12)
+        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
+            run = client.set_experiment_run()
+            run.log_metric('val', metric_val)
+            run.log_hyperparameter('val', hyperparam_val)
+
+        threshold = random.choice(metric_vals)
+        filtered_run_ids = [run._id for run in expt.expt_runs if run.get_metric('val') >= threshold]
+        for expt_run_id, expt_run in zip(filtered_run_ids,
+                                         expt.expt_runs.find("metrics.val >= {}".format(threshold))):
+            assert expt_run_id == expt_run._id
+
+        threshold = random.choice(hyperparam_vals)
+        filtered_run_ids = [run._id for run in expt.expt_runs if run.get_hyperparameter('val') >= threshold]
+        for expt_run_id, expt_run in zip(filtered_run_ids,
+                                         expt.expt_runs.find("hyperparameters.val >= {}".format(threshold))):
+            assert expt_run_id == expt_run._id
+
+    def test_sort(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        vals = random.sample(range(36), 12)
+        for val in vals:
+            client.set_experiment_run().log_metric('val', val)
+
+        sorted_run_ids = [run._id for run in sorted(expt.expt_runs, key=lambda run: run.get_metric('val'))]
+        for expt_run_id, expt_run in zip(sorted_run_ids, expt.expt_runs.sort("metrics.val")):
+            assert expt_run_id == expt_run._id
+
+    def test_top_k(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        metric_vals = random.sample(range(36), 12)
+        hyperparam_vals = random.sample(range(36), 12)
+        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
+            run = client.set_experiment_run()
+            run.log_metric('val', metric_val)
+            run.log_hyperparameter('val', hyperparam_val)
+
+        k = random.randrange(12)
+        top_run_ids = [run._id for run in sorted(expt.expt_runs,
+                                                 key=lambda run: run.get_metric('val'), reverse=True)][:k]
+        for expt_run_id, expt_run in zip(top_run_ids, expt.expt_runs.top_k("metrics.val", k)):
+            assert expt_run_id == expt_run._id
+
+        k = random.randrange(12)
+        top_run_ids = [run._id for run in sorted(expt.expt_runs,
+                                                 key=lambda run: run.get_metric('val'), reverse=True)][:k]
+        for expt_run_id, expt_run in zip(top_run_ids, expt.expt_runs.top_k("metrics.val", k)):
+            assert expt_run_id == expt_run._id
+
+    def test_bottom_k(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        metric_vals = random.sample(range(36), 12)
+        hyperparam_vals = random.sample(range(36), 12)
+        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
+            run = client.set_experiment_run()
+            run.log_metric('val', metric_val)
+            run.log_hyperparameter('val', hyperparam_val)
+
+        k = random.randrange(12)
+        bottom_run_ids = [run._id for run in sorted(expt.expt_runs,
+                                                    key=lambda run: run.get_metric('val'))][:k]
+        for expt_run_id, expt_run in zip(bottom_run_ids, expt.expt_runs.bottom_k("metrics.val", k)):
+            assert expt_run_id == expt_run._id
+
+        k = random.randrange(12)
+        bottom_run_ids = [run._id for run in sorted(expt.expt_runs,
+                                                    key=lambda run: run.get_metric('val'))][:k]
+        for expt_run_id, expt_run in zip(bottom_run_ids, expt.expt_runs.bottom_k("metrics.val", k)):
+            assert expt_run_id == expt_run._id
+>>>>>>> Create tests for ExptRuns querying

--- a/verta/tests/test_protos.py
+++ b/verta/tests/test_protos.py
@@ -1,6 +1,6 @@
-import pytest
-
 import requests
+
+import pytest
 
 
 class TestGetChildren:

--- a/verta/tests/test_workflow.py
+++ b/verta/tests/test_workflow.py
@@ -1,5 +1,10 @@
+import six
+
 import pytest
 import utils
+
+
+if six.PY2: FileNotFoundError = IOError
 
 
 class TestHyperparameters:

--- a/verta/verta/_compat.py
+++ b/verta/verta/_compat.py
@@ -1,0 +1,8 @@
+import six
+
+
+if six.PY2:
+    from urlparse import urlparse
+
+elif six.PY3:
+    from urllib.parse import urlparse

--- a/verta/verta/_compat.py
+++ b/verta/verta/_compat.py
@@ -1,8 +1,0 @@
-import six
-
-
-if six.PY2:
-    from urlparse import urlparse
-
-elif six.PY3:
-    from urllib.parse import urlparse

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,3 +1,5 @@
+import six
+
 import os
 import json
 import pathlib

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -2,7 +2,7 @@ import six
 
 import os
 import json
-import pathlib
+import pathlib2
 import string
 
 import joblib
@@ -75,9 +75,9 @@ def python_to_val_proto(val):
         return Value(null_value=NULL_VALUE)
     if isinstance(val, bool):  # did you know that `bool` is a subclass of `int`?
         return Value(bool_value=val)
-    elif isinstance(val, float) or isinstance(val, int):
+    elif isinstance(val, float) or isinstance(val, six.integer_types):
         return Value(number_value=val)
-    elif isinstance(val, str):
+    elif isinstance(val, six.string_types):
         return Value(string_value=val)
     elif isinstance(val, dict):
         raise NotImplementedError()
@@ -170,7 +170,7 @@ def dump(obj, filename):
 
     # create parent directory
     dirpath = os.path.dirname(filename)  # get parent dir
-    pathlib.Path(dirpath).mkdir(parents=True, exist_ok=True)  # create parent dir
+    pathlib2.Path(dirpath).mkdir(parents=True, exist_ok=True)  # create parent dir
 
     # move file to `filename`
     os.rename(temp_filename, filename)

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1,3 +1,5 @@
+import six
+
 import re
 import ast
 import time

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -3,7 +3,6 @@ import six
 import re
 import ast
 import time
-from urllib.parse import urlparse
 import warnings
 
 import requests
@@ -13,6 +12,7 @@ from ._protos.public.modeldb import ProjectService_pb2 as _ProjectService
 from ._protos.public.modeldb import ExperimentService_pb2 as _ExperimentService
 from ._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
 from . import _utils
+from ._compat import urlparse
 
 
 class ModelDBClient:

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -349,7 +349,7 @@ class Project:
     def _create(auth, socket, proj_name, desc=None, tags=None, attrs=None):
         if attrs is not None:
             attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
-                     for key, value in attrs.items()]
+                     for key, value in six.viewitems(attrs)]
 
         Message = _ProjectService.CreateProject
         msg = Message(name=proj_name, description=desc, tags=tags, metadata=attrs)
@@ -479,7 +479,7 @@ class Experiment:
     def _create(auth, socket, proj_id, expt_name, desc=None, tags=None, attrs=None):
         if attrs is not None:
             attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
-                     for key, value in attrs.items()]
+                     for key, value in six.viewitems(attrs)]
 
         Message = _ExperimentService.CreateExperiment
         msg = Message(project_id=proj_id, name=expt_name,
@@ -535,7 +535,7 @@ class ExperimentRuns:
                '>=': _ExperimentRunService.OperatorEnum.GTE,
                '<':  _ExperimentRunService.OperatorEnum.LT,
                '<=': _ExperimentRunService.OperatorEnum.LTE}
-    _OP_PATTERN = re.compile(r"({})".format('|'.join(sorted(_OP_MAP.keys(), key=lambda s: len(s), reverse=True))))
+    _OP_PATTERN = re.compile(r"({})".format('|'.join(sorted(six.viewkeys(_OP_MAP), key=lambda s: len(s), reverse=True))))
 
     def __init__(self, auth, socket, expt_run_ids=None):
         self._auth = auth
@@ -900,7 +900,7 @@ class ExperimentRun:
     def _create(auth, socket, proj_id, expt_id, expt_run_name, desc=None, tags=None, attrs=None):
         if attrs is not None:
             attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
-                     for key, value in attrs.items()]
+                     for key, value in six.viewitems(attrs)]
 
         Message = _ExperimentRunService.CreateExperimentRun
         msg = Message(project_id=proj_id, experiment_id=expt_id, name=expt_run_name,
@@ -1108,10 +1108,10 @@ class ExperimentRun:
             hyperparams = hyperparams_kwargs
 
         # validate all keys first
-        for key in hyperparams.keys():
+        for key in six.viewkeys(hyperparams):
             _utils.validate_flat_key(key)
 
-        for key, value in hyperparams.items():
+        for key, value in six.viewitems(hyperparams):
             hyperparameter = _CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
             msg = _ExperimentRunService.LogHyperparameter(id=self._id, hyperparameter=hyperparameter)
             data = _utils.proto_to_json(msg)
@@ -1272,7 +1272,7 @@ class ExperimentRun:
         if not load:
             return datasets
         else:
-            for name, filepath in datasets.items():
+            for name, filepath in six.viewitems(datasets):
                 try:
                     datasets[name] = _utils.load(filepath)
                 except Exception as e:
@@ -1391,7 +1391,7 @@ class ExperimentRun:
         if not load:
             return models
         else:
-            for name, filepath in models.items():
+            for name, filepath in six.viewitems(models):
                 try:
                     models[name] = _utils.load(filepath)
                 except Exception as e:
@@ -1510,7 +1510,7 @@ class ExperimentRun:
         if not load:
             return images
         else:
-            for name, filepath in images.items():
+            for name, filepath in six.viewitems(images):
                 try:
                     images[name] = _utils.load(filepath)
                 except Exception as e:

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -246,7 +246,7 @@ class Project:
     def __init__(self, auth, socket,
                  proj_name=None,
                  desc=None, tags=None, attrs=None,
-                 *, _proj_id=None):
+                 _proj_id=None):
         if proj_name is not None and _proj_id is not None:
             raise ValueError("cannot specify both `proj_name` and `_proj_id`")
 
@@ -309,7 +309,7 @@ class Project:
         return "Project {}".format(str(time.time()).replace('.', ''))
 
     @staticmethod
-    def _get(auth, socket, proj_name=None, *, _proj_id=None):
+    def _get(auth, socket, proj_name=None, _proj_id=None):
         if _proj_id is not None:
             Message = _ProjectService.GetProjectById
             msg = Message(id=_proj_id)
@@ -383,7 +383,7 @@ class Experiment:
     def __init__(self, auth, socket,
                  proj_id=None, expt_name=None,
                  desc=None, tags=None, attrs=None,
-                 *, _expt_id=None):
+                 _expt_id=None):
         if expt_name is not None and _expt_id is not None:
             raise ValueError("cannot specify both `expt_name` and `_expt_id`")
 
@@ -448,7 +448,7 @@ class Experiment:
         return "Experiment {}".format(str(time.time()).replace('.', ''))
 
     @staticmethod
-    def _get(auth, socket, proj_id=None, expt_name=None, *, _expt_id=None):
+    def _get(auth, socket, proj_id=None, expt_name=None, _expt_id=None):
         if _expt_id is not None:
             Message = _ExperimentService.GetExperimentById
             msg = Message(id=_expt_id)
@@ -564,7 +564,7 @@ class ExperimentRuns:
         else:
             return NotImplemented
 
-    def find(self, where, ret_all_info=False, *, _proj_id=None, _expt_id=None):
+    def find(self, where, ret_all_info=False, _proj_id=None, _expt_id=None):
         """
         Gets the Experiment Runs from this collection that match predicates `where`.
 
@@ -691,7 +691,7 @@ class ExperimentRuns:
             return self.__class__(self._auth, self._socket,
                                   [expt_run.id for expt_run in response_msg.experiment_runs])
 
-    def top_k(self, key, k, ret_all_info=False, *, _proj_id=None, _expt_id=None):
+    def top_k(self, key, k, ret_all_info=False, _proj_id=None, _expt_id=None):
         """
         Gets the Experiment Runs from this collection with the `k` highest `key`\ s.
 
@@ -741,7 +741,7 @@ class ExperimentRuns:
             return self.__class__(self._auth, self._socket,
                                   [expt_run.id for expt_run in response_msg.experiment_runs])
 
-    def bottom_k(self, key, k, ret_all_info=False, *, _proj_id=None, _expt_id=None):
+    def bottom_k(self, key, k, ret_all_info=False, _proj_id=None, _expt_id=None):
         """
         Gets the Experiment Runs from this collection with the `k` lowest `key`\ s.
 
@@ -810,7 +810,7 @@ class ExperimentRun:
     def __init__(self, auth, socket,
                  proj_id=None, expt_id=None, expt_run_name=None,
                  desc=None, tags=None, attrs=None,
-                 *, _expt_run_id=None):
+                 _expt_run_id=None):
         if expt_run_name is not None and _expt_run_id is not None:
             raise ValueError("cannot specify both `expt_run_name` and `_expt_run_id`")
 
@@ -860,7 +860,7 @@ class ExperimentRun:
         return "ExperimentRun {}".format(str(time.time()).replace('.', ''))
 
     @staticmethod
-    def _get(auth, socket, proj_id=None, expt_id=None, expt_run_name=None, *, _expt_run_id=None):
+    def _get(auth, socket, proj_id=None, expt_id=None, expt_run_name=None, _expt_run_id=None):
         if _expt_run_id is not None:
             Message = _ExperimentRunService.GetExperimentRunById
             msg = Message(id=_expt_run_id)

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1,4 +1,5 @@
 import six
+from six.moves.urllib.parse import urlparse
 
 import re
 import ast
@@ -12,7 +13,6 @@ from ._protos.public.modeldb import ProjectService_pb2 as _ProjectService
 from ._protos.public.modeldb import ExperimentService_pb2 as _ExperimentService
 from ._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
 from . import _utils
-from ._compat import urlparse
 
 
 class ModelDBClient:


### PR DESCRIPTION
## Important Note
An `__init__.py` *must be added* to the root dir of https://github.com/VertaAI/protos-modeldb-python/ because Python2 imports are not very smart. This has been made [an issue in the protos repo](https://github.com/VertaAI/protos-all-python/issues/2).

## Changelog
- enable installation with Python2.7
- add `six` as a dependency for:
  - lazily iterating over dictionaries
  - typechecking integers and strings
  - importing `urlparse` module from std lib
- properly use `pathlib2` as `pathlib` backport
- remove keyword-only-arguments syntax
- create integration tests for `ExperimentRuns` methods
