### PR TITLE
544, 668: Implement utils for artifact storage

### DIFF
--- a/verta/setup.py
+++ b/verta/setup.py
@@ -21,7 +21,6 @@ setup(
     install_requires=[
         "googleapis-common-protos~=1.5",
         "grpcio~=1.16",
-        "joblib~=0.13",
         "pathlib2~=2.1",
         "protobuf~=3.6",
         "requests~=2.21",

--- a/verta/tests/test_workflow.py
+++ b/verta/tests/test_workflow.py
@@ -76,22 +76,12 @@ class TestArtifacts:
         for key, val in datasets.items():
             assert experiment_run.get_dataset(key, load=True) == val
 
-        # get all paths
-        assert experiment_run.get_datasets() == dict(zip(datasets.keys(),
-                                              [output_path.format(key) for key in datasets]))
-
-        # load all objs
-        assert experiment_run.get_datasets(load=True) == datasets
-
         # try load nonlocal obj
         new_key = utils.gen_str()
         datasets[new_key] = output_path.format(new_key)
         experiment_run.log_dataset(new_key, datasets[new_key])
         with pytest.raises(FileNotFoundError):
             experiment_run.get_dataset(new_key, load=True)
-        with pytest.raises(FileNotFoundError):
-            experiment_run.get_datasets(load=True, errors='raise')
-        assert experiment_run.get_datasets(load=True, errors='ignore') == datasets
 
     def test_images(self, experiment_run, output_path):
         # values represent literal artifacts
@@ -116,22 +106,12 @@ class TestArtifacts:
         for key, val in images.items():
             assert experiment_run.get_image(key, load=True) == val
 
-        # get all paths
-        assert experiment_run.get_images() == dict(zip(images.keys(),
-                                            [output_path.format(key) for key in images]))
-
-        # load all objs
-        assert experiment_run.get_images(load=True) == images
-
         # try load nonlocal obj
         new_key = utils.gen_str()
         images[new_key] = output_path.format(new_key)
         experiment_run.log_image(new_key, images[new_key])
         with pytest.raises(FileNotFoundError):
             experiment_run.get_image(new_key, load=True)
-        with pytest.raises(FileNotFoundError):
-            experiment_run.get_images(load=True, errors='raise')
-        assert experiment_run.get_images(load=True, errors='ignore') == images
 
     def test_models(self, experiment_run, output_path):
         # values represent literal artifacts
@@ -156,22 +136,12 @@ class TestArtifacts:
         for key, val in models.items():
             assert experiment_run.get_model(key, load=True) == val
 
-        # get all paths
-        assert experiment_run.get_models() == dict(zip(models.keys(),
-                                            [output_path.format(key) for key in models]))
-
-        # load all objs
-        assert experiment_run.get_models(load=True) == models
-
         # try load nonlocal obj
         new_key = utils.gen_str()
         models[new_key] = output_path.format(new_key)
         experiment_run.log_model(new_key, models[new_key])
         with pytest.raises(FileNotFoundError):
             experiment_run.get_model(new_key, load=True)
-        with pytest.raises(FileNotFoundError):
-            experiment_run.get_models(load=True, errors='raise')
-        assert experiment_run.get_models(load=True, errors='ignore') == models
 
 
 def test_attributes(experiment_run):

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,11 +1,11 @@
 import six
+import six.moves.cPickle as pickle
 
 import os
 import json
 import pathlib2
 import string
 
-import joblib
 
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value, NULL_VALUE
@@ -166,7 +166,7 @@ def dump(obj, filename):
     temp_filename = '.' + os.path.basename(filename)
     while os.path.exists(temp_filename):  # avoid name collisions
         temp_filename += '_'
-    joblib.dump(obj, temp_filename)
+    pickle.dump(obj, temp_filename)
 
     # create parent directory
     dirpath = os.path.dirname(filename)  # get parent dir
@@ -191,4 +191,4 @@ def load(filename):
         Deserialized object.
 
     """
-    return joblib.load(filename)
+    return pickle.load(filename)

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -192,3 +192,33 @@ def load(filename):
 
     """
     return pickle.load(filename)
+
+
+def ensure_bytestream(obj):
+    """
+    Converts an object into a bytestream.
+
+    If `obj` is file-like, its contents will be read into memory and then wrapped in a bytestream.
+    This has a performance cost, but checking beforehand whether an arbitrary file-like object
+    returns bytes is an implementation nightmare.
+
+    If `obj` is not file-like, it will be serialized and then wrapped in a bytestream.
+
+    Parameters
+    ----------
+    obj : file-like or object
+        Object to convert into a bytestream.
+
+    Returns
+    -------
+    file-like
+        Buffered bytestream.
+
+    """
+    try:  # check if obj is file-like
+        contents = obj.read()
+    except AttributeError:  # obj is not file-like
+        bytestring = pickle.dumps(obj)
+    else:
+        bytestring = six.ensure_binary(contents)
+    return six.BytesIO(bytestring)

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1246,54 +1246,6 @@ class ExperimentRun:
         else:
             return _utils.load(filepath)
 
-    def get_datasets(self, load=False, errors='raise'):
-        """
-        Gets file system paths of all datasets from this Experiment Run.
-
-        If `load` is True, this function will instead deserialize and return the datasets themselves.
-
-        Parameters
-        ----------
-        load : bool, default False
-            Whether or not to deserialize and return the models themselves.
-        errors : {'raise', 'ignore'}, default 'raise'
-            How to handle errors during loading if `load` is True.
-            - If 'raise', then an exception will be raised.
-            - If 'ignore', then the filepath for that dataset will be returned instead.
-
-        Returns
-        -------
-        dict of str to {str, object}
-            File system paths of all datasets, or the datasets themselves if `load` is True.
-
-        """
-        if not load and errors != 'raise':
-            raise ValueError("cannot specify `errors` when `load` is False")
-        if errors not in ['raise', 'ignore']:
-            raise ValueError("`errors` must be one of {'raise', 'ignore'}")
-
-        Message = _ExperimentRunService.GetDatasets
-        msg = Message(id=self._id)
-        data = _utils.proto_to_json(msg)
-        response = requests.get("http://{}/v1/experiment-run/getDatasets".format(self._socket),
-                                params=data, headers=self._auth)
-        response.raise_for_status()
-
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
-        datasets = {dataset.key: dataset.path for dataset in response_msg.datasets}
-        if not load:
-            return datasets
-        else:
-            for name, filepath in six.viewitems(datasets):
-                try:
-                    datasets[name] = _utils.load(filepath)
-                except Exception as e:
-                    if errors == 'raise':
-                        raise e
-                    elif errors == 'ignore':
-                        pass
-            return datasets
-
     def log_model(self, key, path, model=None):
         """
         Logs the file system path of a model to this Experiment Run.
@@ -1363,56 +1315,6 @@ class ExperimentRun:
         else:
             return _utils.load(filepath)
 
-    def get_models(self, load=False, errors='raise'):
-        """
-        Gets file system paths of all models from this Experiment Run.
-
-        If `load` is True, this function will instead deserialize and return the models themselves.
-
-        Parameters
-        ----------
-        load : bool, default False
-            Whether or not to deserialize and return the models themselves.
-        errors : {'raise', 'ignore'}, default 'raise'
-            How to handle errors during loading if `load` is True.
-            - If 'raise', then an exception will be raised.
-            - If 'ignore', then the filepath for that model will be returned instead.
-
-        Returns
-        -------
-        dict of str to {str, object}
-            File system paths of all models, or the models themselves if `load` is True.
-
-        """
-        if not load and errors != 'raise':
-            raise ValueError("cannot specify `errors` when `load` is False")
-        if errors not in ['raise', 'ignore']:
-            raise ValueError("`errors` must be one of {'raise', 'ignore'}")
-
-        Message = _ExperimentRunService.GetArtifacts
-        msg = Message(id=self._id)
-        data = _utils.proto_to_json(msg)
-        response = requests.get("http://{}/v1/experiment-run/getArtifacts".format(self._socket),
-                                params=data, headers=self._auth)
-        response.raise_for_status()
-
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
-        models = {artifact.key: artifact.path
-                  for artifact in response_msg.artifacts
-                  if artifact.artifact_type == _CommonService.ArtifactTypeEnum.MODEL}
-        if not load:
-            return models
-        else:
-            for name, filepath in six.viewitems(models):
-                try:
-                    models[name] = _utils.load(filepath)
-                except Exception as e:
-                    if errors == 'raise':
-                        raise e
-                    elif errors == 'ignore':
-                        pass
-            return models
-
     def log_image(self, key, path, image=None):
         """
         Logs the file system path of an image to this Experiment Run.
@@ -1481,56 +1383,6 @@ class ExperimentRun:
             return filepath
         else:
             return _utils.load(filepath)
-
-    def get_images(self, load=False, errors='raise'):
-        """
-        Gets file system paths of all images from this Experiment Run.
-
-        If `load` is True, this function will instead deserialize and return the images themselves.
-
-        Parameters
-        ----------
-        load : bool, default False
-            Whether or not to deserialize and return the models themselves.
-        errors : {'raise', 'ignore'}, default 'raise'
-            How to handle errors during loading if `load` is True.
-            - If 'raise', then an exception will be raised.
-            - If 'ignore', then the filepath for that image will be returned instead.
-
-        Returns
-        -------
-        dict of str to {str, object}
-            File system paths of all images, or the images themselves if `load` is True.
-
-        """
-        if not load and errors != 'raise':
-            raise ValueError("cannot specify `errors` when `load` is False")
-        if errors not in ['raise', 'ignore']:
-            raise ValueError("`errors` must be one of {'raise', 'ignore'}")
-
-        Message = _ExperimentRunService.GetArtifacts
-        msg = Message(id=self._id)
-        data = _utils.proto_to_json(msg)
-        response = requests.get("http://{}/v1/experiment-run/getArtifacts".format(self._socket),
-                                params=data, headers=self._auth)
-        response.raise_for_status()
-
-        response_msg = _utils.json_to_proto(response.json(), Message.Response)
-        images = {artifact.key: artifact.path
-                  for artifact in response_msg.artifacts
-                  if artifact.artifact_type == _CommonService.ArtifactTypeEnum.IMAGE}
-        if not load:
-            return images
-        else:
-            for name, filepath in six.viewitems(images):
-                try:
-                    images[name] = _utils.load(filepath)
-                except Exception as e:
-                    if errors == 'raise':
-                        raise e
-                    elif errors == 'ignore':
-                        pass
-            return images
 
     def log_observation(self, key, value):
         """

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1,4 +1,5 @@
 import six
+import six.moves.cPickle as pickle
 from six.moves.urllib.parse import urlparse
 
 import re

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -927,6 +927,36 @@ class ExperimentRun:
         else:
             response.raise_for_status()
 
+    def _get_url_for_artifact(self, key, method):
+        """
+        Obtains a URL to use for accessing stored artifacts.
+
+        Parameters
+        ----------
+        key : str
+            Name of the artifact.
+        method : {'GET', 'PUT'}
+            REST method to request for the generated URL.
+
+        Returns
+        -------
+        str
+            Generated URL.
+
+        """
+        if method.upper() not in ("GET", "PUT"):
+            raise ValueError("`method` must be one of {'GET', 'PUT'}")
+
+        Message = _ExperimentRunService.GetUrlForArtifact
+        msg = Message(id=self._id, key=key, method=method.upper())
+        data = _utils.proto_to_json(msg)
+        response = requests.post("http://{}/v1/experiment-run/getUrlForArtifact".format(self._socket),
+                                 json=data, headers=self._auth)
+        response.raise_for_status()
+
+        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        return response_msg.url
+
     def log_attribute(self, key, value):
         """
         Logs an attribute to this Experiment Run.


### PR DESCRIPTION
## Changelog
- remove `joblib` as a dependency, sticking with `pickle` for now instead
- remove the functions for getting all artifacts because:
  - they're a hassle to implement properly
  - fetching too many artifacts at once is performance-intensive
- [implement fn for converting an object into a bytestream](https://github.com/VertaAI/modeldb-client/compare/development...convoliution:s3?expand=1#diff-0320d7c96f347d1e665817a9d5a22f98R197)
- [implement fn for obtaining a presigned url for artifact store interaction](https://github.com/VertaAI/modeldb-client/compare/development...convoliution:s3?expand=1#diff-2e381627d68267b10f4c5063ed01f36eR930)