### PR TITLE
Free up dependency pins

### DIFF
--- a/verta/setup.py
+++ b/verta/setup.py
@@ -19,12 +19,12 @@ setup(
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-        "googleapis-common-protos~=1.5",
-        "grpcio~=1.16",
-        "pathlib2~=2.1",
+        "googleapis-common-protos>=1.5",
+        "grpcio>=1.16",
+        "pathlib2>=2.1",
         "pillow>=5.2, <7.0",
-        "protobuf~=3.6",
-        "requests~=2.21",
-        "six~=1.12",
+        "protobuf>=3.6",
+        "requests>=2.21",
+        "six>=1.12",
     ],
 )


### PR DESCRIPTION
Pip's dependency resolver is a hot mess, and also user environments shouldn't be restricted arbitrarily.