### PR TITLE
720: Check for object emptiness

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -214,11 +214,22 @@ def ensure_bytestream(obj):
     file-like
         Buffered bytestream.
 
+    Raises
+    ------
+    ValueError
+        If `obj` contains no data.
+
     """
-    try:  # check if obj is file-like
+    if hasattr(obj, 'read'):  # check if `obj` is file-like
+        try:  # reset cursor to beginning of stream in case user forgot
+            obj.seek(0)
+        except AttributeError:
+            pass
+        # read to cast into binary
         contents = obj.read()
-    except AttributeError:  # obj is not file-like
-        bytestring = pickle.dumps(obj)
-    else:
+        if not len(contents):
+            raise ValueError("object contains no data")
         bytestring = six.ensure_binary(contents)
+    else:  # `obj` is not file-like
+        bytestring = pickle.dumps(obj)
     return six.BytesIO(bytestring)

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -974,8 +974,15 @@ class ExperimentRun:
         artifact_type : int
             Variant of `_CommonService.ArtifactTypeEnum`.
 
+        Raises
+        ------
+        ValueError
+            If `artifact` is an empty string.
+
         """
         path_only = isinstance(artifact, six.string_types)
+        if path_only and not len(artifact):
+            raise ValueError("`artifact` cannot be an empty string")
 
         # log key-path to ModelDB
         Message = _ExperimentRunService.LogArtifact


### PR DESCRIPTION
## Changelog
- attempt to call `seek(0)` on file-like objects before casting into binary
- raise error on empty file-like objects because AWS otherwise returns an unhelpful 501
- raise error on empty strings as artifact paths because protobuf treats them as null values