### PR TITLE
708: Create user-facing utils module

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,11 +1,8 @@
 import six
 import six.moves.cPickle as pickle
 
-import os
 import json
-import pathlib2
 import string
-
 
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value, NULL_VALUE
@@ -146,52 +143,6 @@ def validate_flat_key(key):
     for c in key:
         if c not in _VALID_FLAT_KEY_CHARS:
             raise ValueError("`key` may only contain alphanumeric characters and underscores")
-
-
-def dump(obj, filename):
-    """
-    Serializes `obj` to disk at path `filename`.
-
-    Recursively creates parent directories of `filename` if they do not already exist.
-
-    Parameters
-    ----------
-    obj : object
-        Object to be serialized.
-    filename : str
-        Path to which to write serialized `obj`.
-
-    """
-    # try to dump in current dir to confirm serializability
-    temp_filename = '.' + os.path.basename(filename)
-    while os.path.exists(temp_filename):  # avoid name collisions
-        temp_filename += '_'
-    pickle.dump(obj, temp_filename)
-
-    # create parent directory
-    dirpath = os.path.dirname(filename)  # get parent dir
-    pathlib2.Path(dirpath).mkdir(parents=True, exist_ok=True)  # create parent dir
-
-    # move file to `filename`
-    os.rename(temp_filename, filename)
-
-
-def load(filename):
-    """
-    Deserializes an object from disk at path `filename`.
-
-    Parameters
-    ----------
-    filename : str
-        Path to file containing serialized object.
-
-    Returns
-    -------
-    obj : object
-        Deserialized object.
-
-    """
-    return pickle.load(filename)
 
 
 def ensure_bytestream(obj):

--- a/verta/verta/utils.py
+++ b/verta/verta/utils.py
@@ -1,0 +1,51 @@
+import six
+import six.moves.cPickle as pickle
+
+import os
+import pathlib2
+
+
+def dump(obj, filename):
+    """
+    Serializes `obj` to disk at path `filename`.
+
+    Recursively creates parent directories of `filename` if they do not already exist.
+
+    Parameters
+    ----------
+    obj : object
+        Object to be serialized.
+    filename : str
+        Path to which to write serialized `obj`.
+
+    """
+    # try to dump in current dir to confirm serializability
+    temp_filename = '.' + os.path.basename(filename)
+    while os.path.exists(temp_filename):  # avoid name collisions
+        temp_filename += '_'
+    pickle.dump(obj, temp_filename)
+
+    # create parent directory
+    dirpath = os.path.dirname(filename)  # get parent dir
+    pathlib2.Path(dirpath).mkdir(parents=True, exist_ok=True)  # create parent dir
+
+    # move file to `filename`
+    os.rename(temp_filename, filename)
+
+
+def load(filename):
+    """
+    Deserializes an object from disk at path `filename`.
+
+    Parameters
+    ----------
+    filename : str
+        Path to file containing serialized object.
+
+    Returns
+    -------
+    obj : object
+        Deserialized object.
+
+    """
+    return pickle.load(filename)


### PR DESCRIPTION
## Changelog
- move `dump()` and `load()` into new user-facing utils module
  - this allows for future Verta-related external utilities