### PR TITLE
As requested

### DIFF
--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1378,10 +1378,8 @@ class ExperimentRun:
         input_request = {'token': status['token'],
                          'data': json.dumps(input_data)}
         response = requests.post(prediction_url, data=input_request)
-        if not response.ok:
-            print(response.text)
-        else:
-            print(response.json())
+        response.raise_for_status()
+        return response.json()
 
     def log_model(self, key, model):
         """

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1379,8 +1379,11 @@ class ExperimentRun:
         input_request = {'token': self._prediction_token,
                          'data': json.dumps(input_data)}
         response = requests.post(prediction_url, data=input_request)
-        response.raise_for_status()  # TODO: try refetching api and token
-        return response.json()
+        if not response.ok:
+            return None  # silence error for now
+            # TODO: try refetching api and token
+        else:
+            return response.json()
 
     def log_model(self, key, model):
         """

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -863,6 +863,10 @@ class ExperimentRun:
         self._socket = socket
         self._id = expt_run.id
 
+        # for deployment
+        self._input_headers = None
+        self._prediction_token = None
+
     @property
     def name(self):
         Message = _ExperimentRunService.GetExperimentRunById
@@ -1360,12 +1364,12 @@ class ExperimentRun:
         self._log_artifact("model_api.json", model_api, _CommonService.ArtifactTypeEnum.BLOB)
 
     def predict(self, x):
-        if not hasattr(self, '_input_headers'):
+        if self._input_headers is None:
             model_api = json.loads(self.get_artifact("model_api.json"))
             self._input_headers = [field['name'] for field in model_api['input']['fields']]
         input_data = dict(zip(self._input_headers, x))
 
-        if not hasattr(self, '_prediction_token'):
+        if self._prediction_token is None:
             status_url = "http://{}/api/v1/deployment/status/{}".format(self._socket, self._id)
             response = requests.get(status_url)
             response.raise_for_status()

--- a/workflows/demos/sklearn.ipynb
+++ b/workflows/demos/sklearn.ipynb
@@ -242,7 +242,7 @@
    "outputs": [],
    "source": [
     "for x in itertools.cycle(X_test):\n",
-    "    deployed_model.predict(x)\n",
+    "    print(deployed_model.predict(x))\n",
     "    time.sleep(5)"
    ]
   },


### PR DESCRIPTION
## Changelog
- return prediction response as `dict` instead of just printing it
- cache model api and prediction token on `ExperimentRun` instead of fetching on every prediction