### PR TITLE
721: Read client credentials from env vars

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -7,11 +7,6 @@ import pytest
 import utils
 
 
-HOST_ENV_VAR = "MODELDB_HOST"
-PORT_ENV_VAR = "MODELDB_PORT"
-EMAIL_ENV_VAR = "MODELDB_EMAIL"
-DEV_KEY_ENV_VAR = "MODELDB_DEV_KEY"
-
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = "8080"
 DEFAULT_EMAIL = None
@@ -20,22 +15,22 @@ DEFAULT_DEV_KEY = None
 
 @pytest.fixture(scope='session')
 def host():
-    return os.environ.get(HOST_ENV_VAR, DEFAULT_HOST)
+    return os.environ.get("VERTA_HOST", DEFAULT_HOST)
 
 
 @pytest.fixture(scope='session')
 def port():
-    return os.environ.get(PORT_ENV_VAR, DEFAULT_PORT)
+    return os.environ.get("VERTA_PORT", DEFAULT_PORT)
 
 
 @pytest.fixture(scope='session')
 def email():
-    return os.environ.get(EMAIL_ENV_VAR, DEFAULT_EMAIL)
+    return os.environ.get("VERTA_EMAIL", DEFAULT_EMAIL)
 
 
 @pytest.fixture(scope='session')
 def dev_key():
-    return os.environ.get(DEV_KEY_ENV_VAR, DEFAULT_DEV_KEY)
+    return os.environ.get("VERTA_DEV_KEY", DEFAULT_DEV_KEY)
 
 
 @pytest.fixture(scope='session')

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -2,8 +2,9 @@ import six
 import six.moves.cPickle as pickle
 from six.moves.urllib.parse import urlparse
 
-import re
 import ast
+import os
+import re
 import time
 import warnings
 
@@ -50,6 +51,13 @@ class ModelDBClient:
     _GRPC_PREFIX = "Grpc-Metadata-"
 
     def __init__(self, host, port=None, email=None, dev_key=None):
+        if email is None and 'MODELDB_EMAIL' in os.environ:
+            email = os.environ['MODELDB_EMAIL']
+            print("set email from environment")
+        if dev_key is None and 'MODELDB_DEV_KEY' in os.environ:
+            dev_key = os.environ.get('MODELDB_DEV_KEY')
+            print("set developer key from environment")
+
         if email is None and dev_key is None:
             auth = None
         elif email is not None and dev_key is not None:

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -51,11 +51,11 @@ class ModelDBClient:
     _GRPC_PREFIX = "Grpc-Metadata-"
 
     def __init__(self, host, port=None, email=None, dev_key=None):
-        if email is None and 'MODELDB_EMAIL' in os.environ:
-            email = os.environ['MODELDB_EMAIL']
+        if email is None and 'VERTA_EMAIL' in os.environ:
+            email = os.environ['VERTA_EMAIL']
             print("set email from environment")
-        if dev_key is None and 'MODELDB_DEV_KEY' in os.environ:
-            dev_key = os.environ.get('MODELDB_DEV_KEY')
+        if dev_key is None and 'VERTA_DEV_KEY' in os.environ:
+            dev_key = os.environ.get('VERTA_DEV_KEY')
             print("set developer key from environment")
 
         if email is None and dev_key is None:


### PR DESCRIPTION
## Changelog
- read `$MODELDB_EMAIL` and `$MODELDB_DEV_KEY` from the environment if they are not passed into `ModelDBClient` on init