### PR TITLE
685, 686, 687: Impl marginally more useful reprs

### DIFF
--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -285,6 +285,9 @@ class Project:
         self._socket = socket
         self._id = proj.id
 
+    def __repr__(self):
+        return "<Project \"{}\">".format(self.name)
+
     @property
     def name(self):
         Message = _ProjectService.GetProjectById
@@ -423,6 +426,9 @@ class Experiment:
         self._auth = auth
         self._socket = socket
         self._id = expt.id
+
+    def __repr__(self):
+        return "<Experiment \"{}\">".format(self.name)
 
     @property
     def name(self):
@@ -861,6 +867,9 @@ class ExperimentRun:
         self._auth = auth
         self._socket = socket
         self._id = expt_run.id
+
+    def __repr__(self):
+        return "<ExperimentRun \"{}\">".format(self.name)
 
     @property
     def name(self):


### PR DESCRIPTION
The entity's name is slightly more descriptive than the object's memory address.

If the entity's metadata also have clean string representations in the future, they could be added into these `__repr__`s.