### PR TITLE
864: Use https with auth, http without

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -7,8 +7,8 @@ import pytest
 import utils
 
 
-DEFAULT_HOST = "localhost"
-DEFAULT_PORT = "8080"
+DEFAULT_HOST = None
+DEFAULT_PORT = None
 DEFAULT_EMAIL = None
 DEFAULT_DEV_KEY = None
 

--- a/verta/tests/utils.py
+++ b/verta/tests/utils.py
@@ -21,30 +21,30 @@ def gen_float(start=1, stop=None):
 
 
 def delete_project(id_, client):
-    response = requests.get("http://{}/v1/experiment/getExperimentsInProject".format(client._socket),
-                            params={'project_id': id_}, headers=client._auth)
+    request_url = "{}://{}/v1/experiment/getExperimentsInProject".format(client._scheme, client._socket)
+    response = requests.get(request_url, params={'project_id': id_}, headers=client._auth)
     response.raise_for_status()
     for experiment in response.json().get('experiments', []):
         delete_experiment(experiment['id'], client)
 
-    response = requests.delete("http://{}/v1/project/deleteProject".format(client._socket),
-                               json={'id': id_}, headers=client._auth)
+    request_url = "{}://{}/v1/project/deleteProject".format(client._scheme, client._socket)
+    response = requests.delete(request_url, json={'id': id_}, headers=client._auth)
     response.raise_for_status()
 
 
 def delete_experiment(id_, client):
-    response = requests.get("http://{}/v1/experiment-run/getExperimentRunsInExperiment".format(client._socket),
-                            params={'experiment_id': id_}, headers=client._auth)
+    request_url = "{}://{}/v1/experiment-run/getExperimentRunsInExperiment".format(client._scheme, client._socket)
+    response = requests.get(request_url, params={'experiment_id': id_}, headers=client._auth)
     response.raise_for_status()
     for experiment_run in response.json().get('experiment_runs', []):
         delete_experiment_run(experiment_run['id'], client)
 
-    response = requests.delete("http://{}/v1/experiment/deleteExperiment".format(client._socket),
-                               json={'id': id_}, headers=client._auth)
+    request_url = "{}://{}/v1/experiment/deleteExperiment".format(client._scheme, client._socket)
+    response = requests.delete(request_url, json={'id': id_}, headers=client._auth)
     response.raise_for_status()
 
 
 def delete_experiment_run(id_, client):
-    response = requests.delete("http://{}/v1/experiment-run/deleteExperimentRun".format(client._socket),
-                               json={'id': id_}, headers=client._auth)
+    request_url = "{}://{}/v1/experiment-run/deleteExperimentRun".format(client._scheme, client._socket)
+    response = requests.delete(request_url, json={'id': id_}, headers=client._auth)
     response.raise_for_status()


### PR DESCRIPTION
## Changelog
- allow pytest to work without setting a port in the environment
- add a `_scheme` attribute to classes
  - this is making REST calls more verbose, and highlights the need for a helper function to handle these