### PR TITLE
 548: Implement log_model_for_deployment() 

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -30,6 +30,7 @@ def proto_to_json(msg):
 
     """
     return json.loads(json_format.MessageToJson(msg,
+                                                including_default_value_fields=True,
                                                 preserving_proto_field_name=True,
                                                 use_integers_for_enums=True))
 


### PR DESCRIPTION
## Changelog
- set `including_default_value_fields=True` in `_utils.proto_to_json()` to recover the defaults that protobuf hides
- implement `log_model_for_deployment()`
  - logs artifacts using the keys that the dpeloyment service currently looks for
  - the parameter `dataset` is optional; if it is not provided, then this function will look for an existing dataset artifact, download it to the client, then re-upload it using the deployment-specific key.
    - I hope you cringed reading that as much as I cringed writing it