### PR TITLE
Enable logging/getting Keras models

### DIFF
--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -1,0 +1,39 @@
+import six
+
+import pickle
+
+try:
+    from tensorflow import keras
+except ImportError:
+    pass
+
+
+def deserialize_model(bytestring):
+    """
+    Deserializes a model from a bytestring, attempting various methods.
+
+    If the model is unable to be deserialized, the bytes will be returned as a buffered bytestream.
+
+    Parameters
+    ----------
+    bytestring : bytes
+        Bytes representing the model.
+
+    Returns
+    -------
+    bytestream : obj or file-like
+        Model or buffered bytestream representing the model.
+
+    """
+    bytestream = six.BytesIO(bytestring)
+    try:
+        return keras.models.load_model(bytestream)
+    except NameError:  # Tensorflow not installed
+        pass
+    except OSError:  # not a Keras model
+        pass
+    try:
+        return pickle.load(bytestream)
+    except pickle.UnpicklingError:  # not a pickled object
+        pass
+    return bytestream

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1403,6 +1403,17 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
+        # convert model to bytestream
+        bytestream = six.BytesIO()
+        try:
+            model.save(bytestream)
+        except AttributeError:
+            pass
+
+        if bytestream.getbuffer().nbytes:
+            bytestream.seek(0)
+            model = bytestream
+
         self._log_artifact(key, model, _CommonService.ArtifactTypeEnum.MODEL)
 
     def get_model(self, key):

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -16,6 +16,7 @@ from ._protos.public.modeldb import ProjectService_pb2 as _ProjectService
 from ._protos.public.modeldb import ExperimentService_pb2 as _ExperimentService
 from ._protos.public.modeldb import ExperimentRunService_pb2 as _ExperimentRunService
 from . import _utils
+from . import _artifact_utils
 
 
 class ModelDBClient:

--- a/verta/verta/modeldbclient.py
+++ b/verta/verta/modeldbclient.py
@@ -1442,10 +1442,7 @@ class ExperimentRun:
         if isinstance(model, six.string_types):
             return model
         else:
-            try:
-                return pickle.loads(model)
-            except pickle.UnpicklingError:
-                return six.BytesIO(model)
+            return _artifact_utils.deserialize_model(model)
 
     def log_image(self, key, image):
         """


### PR DESCRIPTION
## Changelog
- create an `_artifact_utils` module to organize serialization deserialization functions.
  - need to migrate exiting functions from `modeldbclient.py`; this is Tech Debt VR-874
- implement function to deserialize models
  - first tries to use `keras`'s `load_model()`, then unpickle, then just return the bytestream
  - thanks to Python shenanigans, `verta` doesn't require installing `tensorflow` but will use the library if the user has it
- implement function to serialize models
  - tries to call `model.save()`, then pickle, then failure
    - `model` can be anything; `save(iostream)` is a fairly common interface