### PR TITLE
 714: Implement duplicate key checks 

### DIFF
--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -49,6 +49,22 @@ class TestArtifacts:
         with pytest.raises(KeyError):
             experiment_run.get_artifact(utils.gen_str())
 
+    # def test_conflict(self, experiment_run):
+    #     artifacts = {
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #     }
+
+    #     for key, artifact in six.viewitems(artifacts):
+    #         experiment_run.log_artifact(key, artifact)
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_artifact(key, artifact)
+
+    #     for key, artifact in reversed(list(six.viewitems(artifacts))):
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_artifact(key, artifact)
+
 
 class TestDatasets:
     def test_path(self, experiment_run):
@@ -65,6 +81,22 @@ class TestDatasets:
         experiment_run.log_dataset(key, dataset)
         assert np.array_equal(experiment_run.get_dataset(key), dataset)
 
+    # def test_conflict(self, experiment_run):
+    #     artifacts = {
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #     }
+
+    #     for key, artifact in six.viewitems(artifacts):
+    #         experiment_run.log_dataset(key, artifact)
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_dataset(key, artifact)
+
+    #     for key, artifact in reversed(list(six.viewitems(artifacts))):
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_dataset(key, artifact)
+
 
 class TestModels:
     def test_path(self, experiment_run):
@@ -80,6 +112,22 @@ class TestModels:
 
         experiment_run.log_model(key, model)
         assert experiment_run.get_model(key).get_params() == model.get_params()
+
+    # def test_conflict(self, experiment_run):
+    #     artifacts = {
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #     }
+
+    #     for key, artifact in six.viewitems(artifacts):
+    #         experiment_run.log_model(key, artifact)
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_model(key, artifact)
+
+    #     for key, artifact in reversed(list(six.viewitems(artifacts))):
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_model(key, artifact)
 
 
 class TestImages:
@@ -131,3 +179,19 @@ class TestImages:
         experiment_run.log_image(key, img)
         assert(np.array_equal(np.asarray(experiment_run.get_image(key).getdata()),
                               np.asarray(img.getdata())))
+
+    # def test_conflict(self, experiment_run):
+    #     artifacts = {
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+    #     }
+
+    #     for key, artifact in six.viewitems(artifacts):
+    #         experiment_run.log_image(key, artifact)
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_image(key, artifact)
+
+    #     for key, artifact in reversed(list(six.viewitems(artifacts))):
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_image(key, artifact)

--- a/verta/tests/test_metadata.py
+++ b/verta/tests/test_metadata.py
@@ -52,59 +52,62 @@ class TestHyperparameters:
         assert experiment_run.get_hyperparameters() == self.hyperparameters
 
 
-def test_attributes(experiment_run):
+class TestAttributes:
     attributes = {
         utils.gen_str(): utils.gen_str(),
         utils.gen_str(): utils.gen_int(),
         utils.gen_str(): utils.gen_float(),
     }
 
-    for key, val in six.viewitems(attributes):
-        experiment_run.log_attribute(key, val)
+    def test_single(self, experiment_run):
+        for key, val in six.viewitems(self.attributes):
+            experiment_run.log_attribute(key, val)
 
-    with pytest.raises(KeyError):
-        experiment_run.get_attribute(utils.gen_str())
+        with pytest.raises(KeyError):
+            experiment_run.get_attribute(utils.gen_str())
 
-    for key, val in six.viewitems(attributes):
-        assert experiment_run.get_attribute(key) == val
+        for key, val in six.viewitems(self.attributes):
+            assert experiment_run.get_attribute(key) == val
 
-    assert experiment_run.get_attributes() == attributes
+        assert experiment_run.get_attributes() == self.attributes
 
 
-def test_metrics(experiment_run):
+class TestMetrics:
     metrics = {
         utils.gen_str(): utils.gen_str(),
         utils.gen_str(): utils.gen_int(),
         utils.gen_str(): utils.gen_float(),
     }
 
-    for key, val in six.viewitems(metrics):
-        experiment_run.log_metric(key, val)
+    def test_single(self, experiment_run):
+        for key, val in six.viewitems(self.metrics):
+            experiment_run.log_metric(key, val)
 
-    with pytest.raises(KeyError):
-        experiment_run.get_metric(utils.gen_str())
+        with pytest.raises(KeyError):
+            experiment_run.get_metric(utils.gen_str())
 
-    for key, val in six.viewitems(metrics):
-        assert experiment_run.get_metric(key) == val
+        for key, val in six.viewitems(self.metrics):
+            assert experiment_run.get_metric(key) == val
 
-    assert experiment_run.get_metrics() == metrics
+        assert experiment_run.get_metrics() == self.metrics
 
 
-def test_observations(experiment_run):
+class TestObservations:
     observations = {
         utils.gen_str(): [utils.gen_str(), utils.gen_str()],
         utils.gen_str(): [utils.gen_int(), utils.gen_int()],
         utils.gen_str(): [utils.gen_float(), utils.gen_float()],
     }
 
-    for key, vals in six.viewitems(observations):
-        for val in vals:
-            experiment_run.log_observation(key, val)
+    def test_single(self, experiment_run):
+        for key, vals in six.viewitems(self.observations):
+            for val in vals:
+                experiment_run.log_observation(key, val)
 
-    with pytest.raises(KeyError):
-        experiment_run.get_observation(utils.gen_str())
+        with pytest.raises(KeyError):
+            experiment_run.get_observation(utils.gen_str())
 
-    for key, val in six.viewitems(observations):
-        assert experiment_run.get_observation(key) == val
+        for key, val in six.viewitems(self.observations):
+            assert experiment_run.get_observation(key) == val
 
-    assert experiment_run.get_observations() == observations
+        assert experiment_run.get_observations() == self.observations

--- a/verta/tests/test_metadata.py
+++ b/verta/tests/test_metadata.py
@@ -51,6 +51,16 @@ class TestHyperparameters:
 
         assert experiment_run.get_hyperparameters() == self.hyperparameters
 
+    def test_conflict(self, experiment_run):
+        for key, val in six.viewitems(self.hyperparameters):
+            experiment_run.log_hyperparameter(key, val)
+            with pytest.raises(ValueError):
+                experiment_run.log_hyperparameter(key, val)
+
+        for key, val in reversed(list(six.viewitems(self.hyperparameters))):
+            with pytest.raises(ValueError):
+                experiment_run.log_hyperparameter(key, val)
+
 
 class TestAttributes:
     attributes = {
@@ -71,6 +81,16 @@ class TestAttributes:
 
         assert experiment_run.get_attributes() == self.attributes
 
+    # def test_conflict(self, experiment_run):
+    #     for key, val in six.viewitems(self.attributes):
+    #         experiment_run.log_attribute(key, val)
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_attribute(key, val)
+
+    #     for key, val in reversed(list(six.viewitems(self.attributes))):
+    #         with pytest.raises(ValueError):
+    #             experiment_run.log_attribute(key, val)
+
 
 class TestMetrics:
     metrics = {
@@ -90,6 +110,16 @@ class TestMetrics:
             assert experiment_run.get_metric(key) == val
 
         assert experiment_run.get_metrics() == self.metrics
+
+    def test_conflict(self, experiment_run):
+        for key, val in six.viewitems(self.metrics):
+            experiment_run.log_metric(key, val)
+            with pytest.raises(ValueError):
+                experiment_run.log_metric(key, val)
+
+        for key, val in reversed(list(six.viewitems(self.metrics))):
+            with pytest.raises(ValueError):
+                experiment_run.log_metric(key, val)
 
 
 class TestObservations:


### PR DESCRIPTION
## Changelog
- in `log_{artifact, attribute, metric, hyperparameter}()`, check for HTTP 409 in the request response, and raise `ValueError`
- in `log_hyperparameters()`, check for any duplicate keys before doing any logging, because I've yet to integrate/test the atomic batch logging RPC
- rename `test_workflow.py` to `test_metadata.py` because I kept forgetting what it was called
- implement integration tests for duplicate key checks

## Notes
The backend currently only checks duplicate keys for metrics and hyperparameters. Adding backend checks for artifacts and attributes is Tech Debt VR-898, and the integration tests for these items are commented out.