### PR TITLE
843: Rename ModelDBClient to Client

### DIFF
--- a/verta/setup.py
+++ b/verta/setup.py
@@ -9,7 +9,7 @@ setup(
     version="0.8.6",
     maintainer="Michael Liu",
     maintainer_email="miliu@verta.ai",
-    description="Python client for interfacing with ModelDB",
+    description="Python client for interfacing with ModelDB and the Verta platform",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://www.verta.ai/",

--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 
-from verta import ModelDBClient
+from verta import Client
 
 import pytest
 import utils
@@ -44,7 +44,7 @@ def output_path():
 
 @pytest.fixture
 def client(host, port, email, dev_key):
-    client = ModelDBClient(host, port, email, dev_key)
+    client = Client(host, port, email, dev_key)
 
     yield client
 

--- a/verta/verta/__init__.py
+++ b/verta/verta/__init__.py
@@ -1,1 +1,1 @@
-from .modeldbclient import ModelDBClient
+from .client import Client

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -19,7 +19,7 @@ from . import _utils
 from . import _artifact_utils
 
 
-class ModelDBClient:
+class Client:
     """
     Object for interfacing with the ModelDB backend.
 
@@ -245,7 +245,7 @@ class Project:
     Runs.
 
     There should not be a need to instantiate this class directly; please use
-    :meth:`ModelDBClient.set_project`.
+    :meth:`Client.set_project`.
 
     Attributes
     ----------
@@ -390,7 +390,7 @@ class Experiment:
     Runs.
 
     There should not be a need to instantiate this class directly; please use
-    :meth:`ModelDBClient.set_experiment`.
+    :meth:`Client.set_experiment`.
 
     Attributes
     ----------
@@ -845,7 +845,7 @@ class ExperimentRun:
     This class provides read/write functionality for Experiment Run metadata.
 
     There should not be a need to instantiate this class directly; please use
-    :meth:`ModelDBClient.set_experiment_run`.
+    :meth:`Client.set_experiment_run`.
 
     Attributes
     ----------

--- a/workflows/demos/sklearn.ipynb
+++ b/workflows/demos/sklearn.ipynb
@@ -153,9 +153,9 @@
    },
    "outputs": [],
    "source": [
-    "from verta import ModelDBClient\n",
+    "from verta import Client\n",
     "\n",
-    "client = ModelDBClient(HOST)\n",
+    "client = Client(HOST)\n",
     "proj = client.set_project(PROJECT_NAME)\n",
     "expt = client.set_experiment(EXPERIMENT_NAME)"
    ]

--- a/workflows/demos/tensorflow.ipynb
+++ b/workflows/demos/tensorflow.ipynb
@@ -154,9 +154,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta import ModelDBClient\n",
+    "from verta import Client\n",
     "\n",
-    "client = ModelDBClient(HOST)\n",
+    "client = Client(HOST)\n",
     "proj = client.set_project(PROJECT_NAME)\n",
     "expt = client.set_experiment(EXPERIMENT_NAME)"
    ]

--- a/workflows/demos/xgboost.ipynb
+++ b/workflows/demos/xgboost.ipynb
@@ -153,9 +153,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta import ModelDBClient\n",
+    "from verta import Client\n",
     "\n",
-    "client = ModelDBClient(HOST)\n",
+    "client = Client(HOST)\n",
     "proj = client.set_project(PROJECT_NAME)\n",
     "expt = client.set_experiment(EXPERIMENT_NAME)"
    ]


### PR DESCRIPTION
## Changelog
- rename `modeldbclient.py` to `client.py`
- rename `ModelDBClient` to `Client`
- update docstrings to reflect renaming
- update test config to reflect renaming
## Notes
@mvartakAtVerta Please make sure this change is reflected in the user guides; I've assigned Tutorials and Documentation VR-899 to you for this.