### PR TITLE
902: Use process ID in default name gen

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -3,7 +3,9 @@ import six.moves.cPickle as pickle
 
 import json
 import numbers
+import os
 import string
+import time
 
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value, NULL_VALUE
@@ -186,3 +188,19 @@ def ensure_bytestream(obj):
     else:  # `obj` is not file-like
         bytestring = pickle.dumps(obj)
     return six.BytesIO(bytestring)
+
+def generate_default_name():
+    """
+    Generates a string that can be used as a default entity name while avoiding collisions.
+
+    The generated string is a concatenation of the current process ID and the current Unix timestamp,
+    such that a collision should only occur if a single process produces two of an entity at the same
+    nanosecond.
+
+    Returns
+    -------
+    name : str
+        String generated from the current process ID and Unix timestamp.
+
+    """
+    return "{}{}".format(os.getpid(), str(time.time()).replace('.', ''))

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -5,7 +5,6 @@ from six.moves.urllib.parse import urlparse
 import ast
 import os
 import re
-import time
 import warnings
 
 import PIL
@@ -322,7 +321,7 @@ class Project:
 
     @staticmethod
     def _generate_default_name():
-        return "Project {}".format(str(time.time()).replace('.', ''))
+        return "Project {}".format(_utils.generate_default_name())
 
     @staticmethod
     def _get(auth, socket, proj_name=None, _proj_id=None):
@@ -469,7 +468,7 @@ class Experiment:
 
     @staticmethod
     def _generate_default_name():
-        return "Experiment {}".format(str(time.time()).replace('.', ''))
+        return "Experiment {}".format(_utils.generate_default_name())
 
     @staticmethod
     def _get(auth, socket, proj_id=None, expt_name=None, _expt_id=None):
@@ -907,7 +906,7 @@ class ExperimentRun:
 
     @staticmethod
     def _generate_default_name():
-        return "ExperimentRun {}".format(str(time.time()).replace('.', ''))
+        return "ExperimentRun {}".format(_utils.generate_default_name())
 
     @staticmethod
     def _get(auth, socket, proj_id=None, expt_id=None, expt_run_name=None, _expt_run_id=None):


### PR DESCRIPTION
Hopefully this fixes the parallel name collision fiasco once and for all.