### PR TITLE
907: Move model serialialization logic to _artifact_utils

### DIFF
--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -2,10 +2,40 @@ import six
 
 import pickle
 
+from verta import _utils
+
 try:
     from tensorflow import keras
 except ImportError:
     pass
+
+
+def serialize_model(model):
+    """
+    Serializes a model into a bytestream, attempting various methods.
+
+    Parameters
+    ----------
+    model : object or file-like
+        Model to convert into a bytestream.
+
+    Returns
+    -------
+    file-like
+        Buffered bytestream.
+
+    """
+    # try to use model-specific serializations
+    bytestream = six.BytesIO()
+    try:
+        model.save(bytestream)
+    except AttributeError:
+        model = _utils.ensure_bytestream(model)
+    else:
+        bytestream.seek(0)
+        model = bytestream
+
+    return model
 
 
 def deserialize_model(bytestring):

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1471,12 +1471,15 @@ class ExperimentRun:
             response = requests.get("{}://{}/v1/experiment-run/getArtifacts".format(self._scheme, self._socket),
                                     params=data, headers=self._auth)
             response.raise_for_status()
+            # recover missing default fields and integer enum values
+            response_msg = _utils.json_to_proto(response.json(), Message.Response)
+            response_json = _utils.proto_to_json(response_msg)
+            artifacts = response_json['artifacts']
             # convert artifacts list into datasets dict
-            artifacts = response.json()['artifacts']
             datasets = {}
             for artifact in artifacts:
-                if artifact.get('artifact_type', 0) == _CommonService.ArtifactTypeEnum.DATA and not artifact.get('path_only'):
-                    datasets[artifact.pop('key', '')] = artifact
+                if artifact['artifact_type'] == _CommonService.ArtifactTypeEnum.DATA and not artifact['path_only']:
+                    datasets[artifact.pop('key')] = artifact
             # look through datasets
             if not datasets:
                 raise ValueError("a training dataset must be provided")

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1494,6 +1494,7 @@ class ExperimentRun:
         if isinstance(dataset, six.string_types):
             dataset = open(dataset, 'rb')
 
+        model = _artifact_utils.serialize_model(model)
         self._log_artifact("model.pkl", model, _CommonService.ArtifactTypeEnum.MODEL)
         self._log_artifact("requirements.txt", requirements, _CommonService.ArtifactTypeEnum.BLOB)
         self._log_artifact("model_api.json", model_api, _CommonService.ArtifactTypeEnum.BLOB)
@@ -1517,16 +1518,7 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
-        # convert model to bytestream
-        bytestream = six.BytesIO()
-        try:
-            model.save(bytestream)
-        except AttributeError:
-            pass
-
-        if bytestream.getbuffer().nbytes:
-            bytestream.seek(0)
-            model = bytestream
+        model = _artifact_utils.serialize_model(model)
 
         self._log_artifact(key, model, _CommonService.ArtifactTypeEnum.MODEL)
 


### PR DESCRIPTION
## Changelog
- create `serialize_model()` fn in `_artifact_utils` to use in both `log_model()` and `log_model_for_deployment()`
  - `log_model_for_deployment()` can't call `log_model()`, because the latter has a key validity check, and by our own standards the deployment-specific keys are not actually valid
  - so to properly bypass this check, I abstracted the model serialization logic to a helper function, which I would've done anyway
- juggle protobuf-python conversions in `log_model_for_deployment()`
  - the json I get back in my request response is missing certain fields because in protobuf (and in Go), default values are equivalent to missing values
  - to get these values back, I need to translate the json into a protobuf message and then back into a `dict`
## Notes
- I actually tested `log_model_for_deployment()` for this PR, and it works!
- the current use of `_artifact_utils::serialize_model()` now means that a model filestream may be read/copied _up to three times_ over the course of a model upload
  - but this behavior will be fixed in the future as `_artifact_utils` is rounded out, and when VR-866 is implemented so that artifact serialization logic can be decoupled a bit more