### PR TITLE
827, 828: Update notebooks with full artifact logging

### DIFF
--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -2,10 +2,40 @@ import six
 
 import pickle
 
+from verta import _utils
+
 try:
     from tensorflow import keras
 except ImportError:
     pass
+
+
+def serialize_model(model):
+    """
+    Serializes a model into a bytestream, attempting various methods.
+
+    Parameters
+    ----------
+    model : object or file-like
+        Model to convert into a bytestream.
+
+    Returns
+    -------
+    file-like
+        Buffered bytestream.
+
+    """
+    # try to use model-specific serializations
+    bytestream = six.BytesIO()
+    try:
+        model.save(bytestream)
+    except AttributeError:
+        model = _utils.ensure_bytestream(model)
+    else:
+        bytestream.seek(0)
+        model = bytestream
+
+    return model
 
 
 def deserialize_model(bytestring):

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,5 +1,4 @@
 import six
-import six.moves.cPickle as pickle
 
 import json
 import numbers
@@ -139,50 +138,6 @@ def validate_flat_key(key):
     for c in key:
         if c not in _VALID_FLAT_KEY_CHARS:
             raise ValueError("`key` may only contain alphanumeric characters, underscores, and dashes")
-
-
-def ensure_bytestream(obj):
-    """
-    Converts an object into a bytestream.
-
-    If `obj` is file-like, its contents will be read into memory and then wrapped in a bytestream.
-    This has a performance cost, but checking beforehand whether an arbitrary file-like object
-    returns bytes is an implementation nightmare.
-
-    If `obj` is not file-like, it will be serialized and then wrapped in a bytestream.
-
-    Parameters
-    ----------
-    obj : file-like or object
-        Object to convert into a bytestream.
-
-    Returns
-    -------
-    file-like
-        Buffered bytestream.
-
-    Raises
-    ------
-    ValueError
-        If `obj` contains no data.
-
-    """
-    if hasattr(obj, 'read'):  # if `obj` is file-like
-        try:  # reset cursor to beginning in case user forgot
-            obj.seek(0)
-        except AttributeError:
-            pass
-        contents = obj.read()  # read to cast into binary
-        try:  # reset cursor to beginning as a courtesy
-            obj.seek(0)
-        except AttributeError:
-            pass
-        if not len(contents):
-            raise ValueError("object contains no data")
-        bytestring = six.ensure_binary(contents)
-    else:  # `obj` is not file-like
-        bytestring = pickle.dumps(obj)
-    return six.BytesIO(bytestring)
 
 def generate_default_name():
     """

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1471,12 +1471,15 @@ class ExperimentRun:
             response = requests.get("{}://{}/v1/experiment-run/getArtifacts".format(self._scheme, self._socket),
                                     params=data, headers=self._auth)
             response.raise_for_status()
+            # recover missing default fields and integer enum values
+            response_msg = _utils.json_to_proto(response.json(), Message.Response)
+            response_json = _utils.proto_to_json(response_msg)
+            artifacts = response_json['artifacts']
             # convert artifacts list into datasets dict
-            artifacts = response.json()['artifacts']
             datasets = {}
             for artifact in artifacts:
-                if artifact.get('artifact_type', 0) == _CommonService.ArtifactTypeEnum.DATA and not artifact.get('path_only'):
-                    datasets[artifact.pop('key', '')] = artifact
+                if artifact['artifact_type'] == _CommonService.ArtifactTypeEnum.DATA and not artifact['path_only']:
+                    datasets[artifact.pop('key')] = artifact
             # look through datasets
             if not datasets:
                 raise ValueError("a training dataset must be provided")

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1041,7 +1041,7 @@ class ExperimentRun:
         if not path_only:
             # upload artifact to artifact store
             url = self._get_url_for_artifact(key, "PUT")
-            artifact_stream = _utils.ensure_bytestream(artifact)
+            artifact_stream = _artifact_utils.ensure_bytestream(artifact)
             response = requests.put(url, data=artifact_stream)
             response.raise_for_status()
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1494,6 +1494,7 @@ class ExperimentRun:
         if isinstance(dataset, six.string_types):
             dataset = open(dataset, 'rb')
 
+        model = _artifact_utils.serialize_model(model)
         self._log_artifact("model.pkl", model, _CommonService.ArtifactTypeEnum.MODEL)
         self._log_artifact("requirements.txt", requirements, _CommonService.ArtifactTypeEnum.BLOB)
         self._log_artifact("model_api.json", model_api, _CommonService.ArtifactTypeEnum.BLOB)
@@ -1517,16 +1518,7 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
-        # convert model to bytestream
-        bytestream = six.BytesIO()
-        try:
-            model.save(bytestream)
-        except AttributeError:
-            pass
-
-        if bytestream.getbuffer().nbytes:
-            bytestream.seek(0)
-            model = bytestream
+        model = _artifact_utils.serialize_model(model)
 
         self._log_artifact(key, model, _CommonService.ArtifactTypeEnum.MODEL)
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1041,7 +1041,7 @@ class ExperimentRun:
         if not path_only:
             # upload artifact to artifact store
             url = self._get_url_for_artifact(key, "PUT")
-            artifact_stream = _artifact_utils.ensure_bytestream(artifact)
+            artifact_stream, _ = _artifact_utils.ensure_bytestream(artifact)
             response = requests.put(url, data=artifact_stream)
             response.raise_for_status()
 
@@ -1486,7 +1486,7 @@ class ExperimentRun:
             if 'train_data' not in datasets:
                 # fetch another dataset
                 dataset = self.get_dataset(datasets.popitem()[0])
-        
+
         # open files
         if isinstance(model, six.string_types):
             model = open(model, 'rb')

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1497,7 +1497,7 @@ class ExperimentRun:
         if isinstance(dataset, six.string_types):
             dataset = open(dataset, 'rb')
 
-        model = _artifact_utils.serialize_model(model)
+        model, method, model_type = _artifact_utils.serialize_model(model)
         self._log_artifact("model.pkl", model, _CommonService.ArtifactTypeEnum.MODEL)
         self._log_artifact("requirements.txt", requirements, _CommonService.ArtifactTypeEnum.BLOB)
         self._log_artifact("model_api.json", model_api, _CommonService.ArtifactTypeEnum.BLOB)
@@ -1521,7 +1521,7 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
-        model = _artifact_utils.serialize_model(model)
+        model, _, _ = _artifact_utils.serialize_model(model)
 
         self._log_artifact(key, model, _CommonService.ArtifactTypeEnum.MODEL)
 

--- a/workflows/demos/sklearn.ipynb
+++ b/workflows/demos/sklearn.ipynb
@@ -35,7 +35,7 @@
     "- **scikit-learn**'s `LinearRegression` model\n",
     "- **scikit-learn**'s `GridSearchCV` utility for performing grid search and cross-validation\n",
     "- **verta**'s Python client logging the grid search results\n",
-    "- **verta**'s Python client retrieving the best run from the grid search"
+    "- **verta**'s Python client retrieving the best run from the grid search to calculate and log full training accuracy"
    ]
   },
   {
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HOST = \"demo2.verta.ai\"\n",
+    "HOST = \"demo1.verta.ai\"\n",
     "\n",
     "PROJECT_NAME = \"Iris Multiclassification\"\n",
     "EXPERIMENT_NAME = \"Logistic Regression\""
@@ -116,6 +116,18 @@
     "\n",
     "X = data['data']\n",
     "y = data['target']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(np.hstack((X, y.reshape(-1, 1))),\n",
+    "                  columns=data['feature_names'] + ['species'])\n",
+    "\n",
+    "df.head()"
    ]
   },
   {
@@ -193,7 +205,7 @@
     "    run = client.set_experiment_run()\n",
     "    \n",
     "    # log training data\n",
-    "    run.log_dataset(\"train_data\", data)\n",
+    "    run.log_dataset(\"train_data\", df)\n",
     "    \n",
     "    # log hyperparameters\n",
     "    run.log_hyperparameters(**run_result['params'])\n",
@@ -289,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#best_run.log_model_for_deployment(model, \"requirements.txt\", \"model_api.json\")"
+    "best_run.log_model_for_deployment(model, df, \"../requirements.txt\")"
    ]
   },
   {

--- a/workflows/demos/tensorflow.ipynb
+++ b/workflows/demos/tensorflow.ipynb
@@ -34,7 +34,7 @@
     "This example features:\n",
     "- **Tensorflow**'s Keras API for building neural networks\n",
     "- **verta**'s Python client logging observations and artifacts during validation\n",
-    "- **verta**'s Python client retrieving artifacts from validation"
+    "- **verta**'s Python client retrieving the loss/accuracy plot and the trained model from the validation process"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HOST = \"demo2.verta.ai\"\n",
+    "HOST = \"demo1.verta.ai\"\n",
     "\n",
     "PROJECT_NAME = \"MNIST Multiclassification\"\n",
     "EXPERIMENT_NAME = \"FC-NN\""
@@ -76,6 +76,7 @@
     "import time\n",
     "\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from sklearn import datasets\n",
@@ -115,6 +116,18 @@
     "\n",
     "X = data['data']\n",
     "y = data['target']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(np.hstack((X, y.reshape(-1, 1))),\n",
+    "                  columns=[\"pixel_{}\".format(i) for i in range(X.shape[-1])] + ['digit'])\n",
+    "\n",
+    "df.head()"
    ]
   },
   {
@@ -216,7 +229,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run.log_dataset(\"train_data\", data)"
+    "run.log_dataset(\"train_data\", df)"
    ]
   },
   {
@@ -363,7 +376,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#run.log_model_for_deployment(model, \"requirements.txt\", \"model_api.json\")"
+    "run.log_model_for_deployment(model, df, \"../requirements.txt\")"
    ]
   },
   {

--- a/workflows/demos/xgboost.ipynb
+++ b/workflows/demos/xgboost.ipynb
@@ -35,7 +35,7 @@
     "- **XGBoost**'s native API for cross-validating and training gradient-boosted trees\n",
     "- **scikit-learn**'s `ParameterGrid` utility for iterating over a hyperparameter grid\n",
     "- **verta**'s Python client integrated into the grid search loop\n",
-    "- **verta**'s Python client retrieving the best run from the grid search"
+    "- **verta**'s Python client retrieving the best run from the grid search to calculate and log full training accuracy"
    ]
   },
   {
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HOST = \"demo2.verta.ai\"\n",
+    "HOST = \"demo1.verta.ai\"\n",
     "\n",
     "PROJECT_NAME = \"Wine Multiclassification\"\n",
     "EXPERIMENT_NAME = \"Boosted Trees\""
@@ -78,6 +78,7 @@
     "import time\n",
     "\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "\n",
     "from sklearn import datasets\n",
     "from sklearn import model_selection\n",
@@ -118,6 +119,18 @@
     "y = data['target']\n",
     "\n",
     "dtrain = xgb.DMatrix(X, label=y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(np.hstack((X, y.reshape(-1, 1))),\n",
+    "                  columns=data['feature_names'] + ['species'])\n",
+    "\n",
+    "df.head()"
    ]
   },
   {
@@ -177,7 +190,7 @@
     "    run = client.set_experiment_run()\n",
     "    \n",
     "    # log training data\n",
-    "    run.log_dataset(\"train_data\", data)\n",
+    "    run.log_dataset(\"train_data\", df)\n",
     "    \n",
     "    # log hyperparameters\n",
     "    run.log_hyperparameters(**hyperparams)\n",
@@ -284,7 +297,7 @@
    },
    "outputs": [],
    "source": [
-    "#best_run.log_model_for_deployment(model, \"requirements.txt\", \"model_api.json\")"
+    "best_run.log_model_for_deployment(model, df, \"../requirements.txt\")"
    ]
   },
   {


### PR DESCRIPTION
This is built on #77; you can view the true diff [here](https://github.com/convoliution/modeldb-client/compare/sacramento...VertaAI:notebooks).
## Changelog
- create and log `pandas` `DataFrames`
- uncomment `log_model_for_deployment()`