### PR TITLE
569: Associate timestamps with observations

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,5 +1,6 @@
 import six
 
+from datetime import datetime
 import json
 import numbers
 import os
@@ -224,3 +225,16 @@ def generate_default_name():
 
     """
     return "{}{}".format(os.getpid(), str(time.time()).replace('.', ''))
+
+
+def now():
+    """
+    Returns the current Unix timestamp with millisecond resolution.
+
+    Returns
+    -------
+    now : int
+        Current Unix timestamp in milliseconds.
+
+    """
+    return int(datetime.now().timestamp()*10**3)

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -289,6 +289,25 @@ def ensure_timestamp(timestamp):
         raise TypeError("unable to parse timestamp of type {}".format(type(timestamp)))
 
 
+def timestamp_to_str(timestamp):
+    """
+    Converts a Unix timestamp into a human-readable string representation.
+
+    Parameters
+    ----------
+    timestamp : int
+        Numerical Unix timestamp.
+
+    Returns
+    -------
+    str
+        Human-readable string representation of `timestamp`.
+
+    """
+    num_digits = len(str(timestamp))
+    return str(datetime.fromtimestamp(timestamp*10**(10 - num_digits)))
+
+
 def now():
     """
     Returns the current Unix timestamp with millisecond resolution.

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -5,7 +5,6 @@ import json
 import numbers
 import os
 import string
-import time
 
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value, NULL_VALUE
@@ -224,7 +223,26 @@ def generate_default_name():
         String generated from the current process ID and Unix timestamp.
 
     """
-    return "{}{}".format(os.getpid(), str(time.time()).replace('.', ''))
+    return "{}{}".format(os.getpid(), str(datetime.now().timestamp()).replace('.', ''))
+
+
+def timestamp_to_ms(timestamp):
+    """
+    Converts a Unix timestamp into one with millisecond resolution.
+
+    Parameters
+    ----------
+    timestamp : float or int
+        Unix timestamp.
+
+    Returns
+    -------
+    int
+        `timestamp` with millisecond resolution (13 integer digits).
+
+    """
+    num_integer_digits = len(str(timestamp).split('.')[0])
+    return int(timestamp*10**(13 - num_integer_digits))
 
 
 def now():
@@ -237,4 +255,4 @@ def now():
         Current Unix timestamp in milliseconds.
 
     """
-    return int(datetime.now().timestamp()*10**3)
+    return timestamp_to_ms(datetime.now().timestamp())

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1726,7 +1726,7 @@ class ExperimentRun:
         if len(response_msg.observations) == 0:
             raise KeyError(key)
         else:
-            return [_utils.val_proto_to_python(observation.attribute.value)
+            return [_utils.unravel_observation(observation)[1:]  # drop key from tuple
                     for observation in response_msg.observations]  # TODO: support Artifacts
 
     def get_observations(self):

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1665,7 +1665,7 @@ class ExperimentRun:
             except pickle.UnpicklingError:
                 return six.BytesIO(artifact)
 
-    def log_observation(self, key, value):
+    def log_observation(self, key, value, timestamp=None):
         """
         Logs an observation to this Experiment Run.
 
@@ -1678,12 +1678,20 @@ class ExperimentRun:
             Name of the observation.
         value : one of {None, bool, float, int, str}
             Value of the observation.
+        timestamp: str or float or int, optional
+            String representation of a datetime or numerical Unix timestamp. If not provided, the
+            current time will be used.
 
         """
         _utils.validate_flat_key(key)
 
+        if timestamp is None:
+            timestamp = _utils.now()
+        else:
+            timestamp = _utils.ensure_timestamp(timestamp)
+
         attribute = _CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
-        observation = _ExperimentRunService.Observation(attribute=attribute)  # TODO: support Artifacts
+        observation = _ExperimentRunService.Observation(attribute=attribute, timestamp=timestamp)  # TODO: support Artifacts
         msg = _ExperimentRunService.LogObservation(id=self._id, observation=observation)
         data = _utils.proto_to_json(msg)
         response = requests.post("{}://{}/v1/experiment-run/logObservation".format(self._scheme, self._socket),

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1682,6 +1682,11 @@ class ExperimentRun:
             String representation of a datetime or numerical Unix timestamp. If not provided, the
             current time will be used.
 
+        Warnings
+        --------
+        If `timestamp` is provided by the user, it must contain timezone information. Otherwise,
+        it will be interpreted as UTC.
+
         """
         _utils.validate_flat_key(key)
 


### PR DESCRIPTION
## Changelog
- import `datetime` instead of `time` in _utils.py
- optionally import `pandas` in _utils.py
- implement `unravel_observation()` (singular), which lightly converts an `Observation` protobuf message into a Python tuple
- change `unravel_observations()` (plural) to use `unravel_observation()` (singular)
- change `generate_default_name()` to use the `datetime` module instead of `time`, to keep the number of imports low
- implement `timestamp_to_ms()`, which ensures that a numerical Unix timestamp is with millisecond precision (13 integer digits)
- implement `ensure_timestamp()`, which converts a string datetime representation (e.g. "Oct 30, 2017") into a Unix timestamp with millisecond precision, and also converts already-numerical timestamps to millisecond precision
- implement `timestamp_to_str()`, which converts a numerical Unix timestamp to a human-readable string representation
- implement `now()`, which returns the current Unix timestamp with millisecond precision
- add optional `timestamp` parameter to `log_observation()`
- enable returning timestamps with observations from `get_observation()` and `get_observations()`