### PR TITLE
554: Implement logging/getting tags on ExperimentRuns

### DIFF
--- a/verta/tests/test_metadata.py
+++ b/verta/tests/test_metadata.py
@@ -7,6 +7,28 @@ import utils
 if six.PY2: FileNotFoundError = IOError
 
 
+class TestTags:
+    tags = [utils.gen_str() for _ in range(3)]
+
+    def test_single(self, experiment_run):
+        for tag in self.tags:
+            experiment_run.log_tag(tag)
+
+        assert set(experiment_run.get_tags()) == set(self.tags)
+
+    def test_multiple(self, experiment_run):
+        experiment_run.log_tags(self.tags)
+
+        assert set(experiment_run.get_tags()) == set(self.tags)
+
+    def test_duplicates(self, experiment_run):
+        experiment_run.log_tags(self.tags)
+        for tag in self.tags:
+            experiment_run.log_tag(tag)
+
+        assert set(experiment_run.get_tags()) == set(self.tags)
+
+
 class TestHyperparameters:
     hyperparameters = {
         utils.gen_str(): utils.gen_str(),

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1112,6 +1112,71 @@ class ExperimentRun:
 
             return response.content
 
+    def log_tag(self, tag):
+        """
+        Logs a tag to this Experiment Run.
+
+        Tags are short textual labels used to help identify a run, such as its purpose or its environment.
+
+        Parameters
+        ----------
+        tag : str
+            Tag.
+
+        """
+        if not isinstance(tag, six.string_types):
+            raise TypeError("`tag` must be a string")
+
+        Message = _ExperimentRunService.AddExperimentRunTags
+        msg = Message(id=self._id, tags=[tag])
+        data = _utils.proto_to_json(msg)
+        response = requests.post("{}://{}/v1/experiment-run/addExperimentRunTags".format(self._scheme, self._socket),
+                                 json=data, headers=self._auth)
+        response.raise_for_status()
+
+    def log_tags(self, tags):
+        """
+        Logs multiple tags to this Experiment Run.
+
+        Parameters
+        ----------
+        tags : list of str
+            Tags.
+
+        """
+        if isinstance(tags, six.string_types):
+            raise TypeError("`tags` must be an iterable of strings")
+        for tag in tags:
+            if not isinstance(tag, six.string_types):
+                raise TypeError("`tags` must be an iterable of strings")
+
+        Message = _ExperimentRunService.AddExperimentRunTags
+        msg = Message(id=self._id, tags=tags)
+        data = _utils.proto_to_json(msg)
+        response = requests.post("{}://{}/v1/experiment-run/addExperimentRunTags".format(self._scheme, self._socket),
+                                 json=data, headers=self._auth)
+        response.raise_for_status()
+
+    def get_tags(self):
+        """
+        Gets all tags from this Experiment Run.
+
+        Returns
+        -------
+        list of str
+            All tags.
+
+        """
+        Message = _CommonService.GetTags
+        msg = Message(id=self._id)
+        data = _utils.proto_to_json(msg)
+        response = requests.get("{}://{}/v1/experiment-run/getExperimentRunTags".format(self._scheme, self._socket),
+                                params=data, headers=self._auth)
+        response.raise_for_status()
+
+        response_msg = _utils.json_to_proto(response.json(), Message.Response)
+        return response_msg.tags
+
     def log_attribute(self, key, value):
         """
         Logs an attribute to this Experiment Run.


### PR DESCRIPTION
`TestTags::test_duplicates()` current fails, but the test itself checks for intended behavior (silently ignore duplicate logged tags). Its success is blocked on backend changes by @ravishetye, but I do not believe that should block this PR.