### PR TITLE
Change batch logging functions to take a dict instead of kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Come see [our user guide and documentation](https://verta.readthedocs.io/en/docs
     1. `git submodule init`
     1. `git submodule update`
     1. `cd verta/`
-    1. `pip3 install -e .`
-        1. this means you don't have to rerun `pip3 install` whenever you make changes
-    1. (optional) `pip3 install -r requirements.txt`
+    1. `pip install -e .`
+        1. this means you don't have to rerun `pip install` whenever you make changes
+    1. (optional) `pip install -r requirements.txt`
         1. this installs packages for PyPI publication, unit testing, and documentation
 1. use Client
 1. tackle issues

--- a/verta/docs/guides/guides.rst
+++ b/verta/docs/guides/guides.rst
@@ -12,7 +12,7 @@ Guides
 
     # set hyperparameters
     hyperparams = {'C': 1e-3, 'solver': "lbfgs"}
-    run.log_hyperparameters(**hyperparams)
+    run.log_hyperparameters(hyperparams)
 
     # train model
     model = sklearn.linear_model.LogisticRegression(**hyperparams)

--- a/verta/docs/guides/workflow.rst
+++ b/verta/docs/guides/workflow.rst
@@ -32,7 +32,7 @@ We begin with the :py:mod:`~verta.client.Client`:
 
 ``host`` points the client to the Verta back end, ``email`` is the address you have associated
 with your GitHub account, and ``dev_key`` is your developer key which you can obtain though the Verta
-Web App. 
+Web App.
 
 Your email and developer key can also be set using the environment variables ``$VERTA_EMAIL`` and
 ``$VERTA_DEV_KEY``, so you don't have to explicitly type them into your workflow.
@@ -116,7 +116,7 @@ That's not much better than purely guessing! So how do we keep a more permanent 
 .. code-block:: python
 
     >>> run.log_dataset("train_data", digits)
-    >>> run.log_hyperparameters(**hyperparams)
+    >>> run.log_hyperparameters(hyperparams)
     >>> run.log_model("model", model)
     >>> run.log_metric("train_acc", train_acc)
 
@@ -131,7 +131,7 @@ linear kernel—this time interweaving the logging statements with our training 
     >>> run = client.set_experiment_run("Linear Kernel")
     >>> run.log_dataset("train_data", digits)
     >>> hyperparams['kernel'] = 'linear'
-    >>> run.log_hyperparameters(**hyperparams)
+    >>> run.log_hyperparameters(hyperparams)
     >>> clf = SVC(**hyperparams).fit(X, y)
     >>> run.log_model("model", model)
     >>> train_acc = clf.score(X, y)

--- a/verta/tests/test_metadata.py
+++ b/verta/tests/test_metadata.py
@@ -49,7 +49,7 @@ class TestHyperparameters:
         assert experiment_run.get_hyperparameters() == self.hyperparameters
 
     def test_batch(self, experiment_run):
-        experiment_run.log_hyperparameters(**self.hyperparameters)
+        experiment_run.log_hyperparameters(self.hyperparameters)
 
         with pytest.raises(KeyError):
             experiment_run.get_hyperparameter(utils.gen_str())
@@ -71,11 +71,11 @@ class TestHyperparameters:
 
     def test_atomic(self, experiment_run):
         """Test if batch completely fails even if only a single key conflicts."""
-        experiment_run.log_hyperparameters(**self.hyperparameters)
+        experiment_run.log_hyperparameters(self.hyperparameters)
 
         for key, val in six.viewitems(self.hyperparameters):
             with pytest.raises(ValueError):
-                experiment_run.log_hyperparameters(**{
+                experiment_run.log_hyperparameters({
                     key: val,
                     utils.gen_str(): utils.gen_str(),
                 })
@@ -103,7 +103,7 @@ class TestAttributes:
         assert experiment_run.get_attributes() == self.attributes
 
     def test_batch(self, experiment_run):
-        experiment_run.log_attributes(**self.attributes)
+        experiment_run.log_attributes(self.attributes)
 
         with pytest.raises(KeyError):
             experiment_run.get_attribute(utils.gen_str())
@@ -125,11 +125,11 @@ class TestAttributes:
 
     def test_atomic(self, experiment_run):
         """Test if batch completely fails even if only a single key conflicts."""
-        experiment_run.log_attributes(**self.attributes)
+        experiment_run.log_attributes(self.attributes)
 
         for key, val in six.viewitems(self.attributes):
             with pytest.raises(ValueError):
-                experiment_run.log_attributes(**{
+                experiment_run.log_attributes({
                     key: val,
                     utils.gen_str(): utils.gen_str(),
                 })
@@ -157,7 +157,7 @@ class TestMetrics:
         assert experiment_run.get_metrics() == self.metrics
 
     def test_batch(self, experiment_run):
-        experiment_run.log_metrics(**self.metrics)
+        experiment_run.log_metrics(self.metrics)
 
         with pytest.raises(KeyError):
             experiment_run.get_metric(utils.gen_str())
@@ -179,11 +179,11 @@ class TestMetrics:
 
     def test_atomic(self, experiment_run):
         """Test if batch completely fails even if only a single key conflicts."""
-        experiment_run.log_metrics(**self.metrics)
+        experiment_run.log_metrics(self.metrics)
 
         for key, val in six.viewitems(self.metrics):
             with pytest.raises(ValueError):
-                experiment_run.log_metrics(**{
+                experiment_run.log_metrics({
                     key: val,
                     utils.gen_str(): utils.gen_str(),
                 })

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1222,19 +1222,14 @@ class ExperimentRun:
             else:
                 response.raise_for_status()
 
-    def log_attributes(self, **attributes):
+    def log_attributes(self, attributes):
         """
-        Logs potentially multiple attributes to this Experiment Run using keyword arguments.
+        Logs potentially multiple attributes to this Experiment Run.
 
         Parameters
         ----------
-        **attributes : {None, bool, float, int, str}
+        attributes : dict of str to {None, bool, float, int, str}
             Attributes.
-
-        Examples
-        --------
-        >>> run.log_attributes(team="sales")
-        >>> run.log_attributes(**{"training_time_hours": 48})
 
         """
         # validate all keys first
@@ -1337,19 +1332,14 @@ class ExperimentRun:
             else:
                 response.raise_for_status()
 
-    def log_metrics(self, **metrics):
+    def log_metrics(self, metrics):
         """
-        Logs potentially multiple metrics to this Experiment Run using keyword arguments.
+        Logs potentially multiple metrics to this Experiment Run.
 
         Parameters
         ----------
-        **metrics : {None, bool, float, int, str}
+        metrics : dict of str to {None, bool, float, int, str}
             Metrics.
-
-        Examples
-        --------
-        >>> run.log_metrics(accuracy=0.87)
-        >>> run.log_metrics(**{"loss": 1.56})
 
         """
         # validate all keys first
@@ -1451,19 +1441,14 @@ class ExperimentRun:
             else:
                 response.raise_for_status()
 
-    def log_hyperparameters(self, **hyperparams):
+    def log_hyperparameters(self, hyperparams):
         """
-        Logs potentially multiple hyperparameters to this Experiment Run using keyword arguments.
+        Logs potentially multiple hyperparameters to this Experiment Run.
 
         Parameters
         ----------
-        **hyperparameters : {None, bool, float, int, str}
+        hyperparameters : dict of str to {None, bool, float, int, str}
             Hyperparameters.
-
-        Examples
-        --------
-        >>> run.log_hyperparameters(loss_fn="binary_cross_entropy")
-        >>> run.log_hyperparameters(**{"penalty": "l2"})
 
         """
         # validate all keys first

--- a/workflows/demos/census-end-to-end.ipynb
+++ b/workflows/demos/census-end-to-end.ipynb
@@ -196,7 +196,7 @@
     "                                                                 shuffle=True)\n",
     "    \n",
     "    # log hyperparameters\n",
-    "    run.log_hyperparameters(**hyperparams)\n",
+    "    run.log_hyperparameters(hyperparams)\n",
     "    print(hyperparams, end=' ')\n",
     "    \n",
     "    # create and train model\n",

--- a/workflows/examples/sklearn.ipynb
+++ b/workflows/examples/sklearn.ipynb
@@ -208,7 +208,7 @@
     "    run.log_dataset(\"train_data\", df)\n",
     "    \n",
     "    # log hyperparameters\n",
-    "    run.log_hyperparameters(**run_result['params'])\n",
+    "    run.log_hyperparameters(run_result['params'])\n",
     "    \n",
     "    # log accuracy for each validation fold\n",
     "    for obs_key in [\"split{}_test_score\".format(i) for i in range(5)]:\n",

--- a/workflows/examples/tensorflow.ipynb
+++ b/workflows/examples/tensorflow.ipynb
@@ -203,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run.log_hyperparameters(**hyperparams)\n",
+    "run.log_hyperparameters(hyperparams)\n",
     "\n",
     "model = keras.models.Sequential()\n",
     "model.add(keras.layers.Flatten())\n",

--- a/workflows/examples/xgboost.ipynb
+++ b/workflows/examples/xgboost.ipynb
@@ -193,7 +193,7 @@
     "    run.log_dataset(\"train_data\", df)\n",
     "    \n",
     "    # log hyperparameters\n",
-    "    run.log_hyperparameters(**hyperparams)\n",
+    "    run.log_hyperparameters(hyperparams)\n",
     "    \n",
     "    # run cross validation on hyperparameters\n",
     "    cv_history = xgb.cv(hyperparams, dtrain,\n",


### PR DESCRIPTION
In #87, I removed the ability to pass a `dict` into batch logging functions  
(e.g. `log_metrics(metrics_dict)`)  
and instead only supported dictionary unpacking  
(e.g. `log_metrics(**metrics_dict)`).

This morning, I realized that this is one of the worst ideas I've ever had, because this means that any future arguments we may add to these functions will potentially have collisions with metric keys.

Basically, if we added a parameter to `log_metrics()` called `lowercase` or something, the user would be unable to use this function to log a metric with the name `"lowercase"`. It's highly unlikely to come up but if it does, it will be a hassle to debug and fix, so we might as well reduce the chance to zero.