### PR TITLE
Re-establish Py2 compatibility

### DIFF
--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -172,7 +172,7 @@ class TestImages:
         img = PIL.Image.new('RGB', (64, 64), 'white')
         PIL.ImageDraw.Draw(img).arc(np.r_[np.random.randint(32, size=(2)),
                                           np.random.randint(32, 64, size=(2))].tolist(),
-                                    *np.random.randint(360, size=2),
+                                    np.random.randint(360), np.random.randint(360),
                                     'black')
 
         experiment_run.log_image(key, img)

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -255,7 +255,27 @@ def generate_default_name():
         String generated from the current process ID and Unix timestamp.
 
     """
-    return "{}{}".format(os.getpid(), str(datetime.now().timestamp()).replace('.', ''))
+    return "{}{}".format(os.getpid(), str(to_timestamp(datetime.now())).replace('.', ''))
+
+
+def to_timestamp(dt):
+    """
+    Converts a datetime instance into a Unix timestamp.
+
+    Equivalent to Python 3's ``dt.timestamp()`` on a naive datetime instance.
+
+    Parameters
+    ----------
+    dt : datetime.datetime
+        datetime instance.
+
+    Returns
+    -------
+    float
+        Unix timestamp.
+
+    """
+    return (dt - datetime.fromtimestamp(0)).total_seconds()
 
 
 def timestamp_to_ms(timestamp):
@@ -302,7 +322,7 @@ def ensure_timestamp(timestamp):
             return timestamp_to_ms(pd.Timestamp(timestamp).timestamp())
         except NameError:  # pandas not installed
             try:  # fall back on std lib, and parse as ISO 8601
-                timestamp_to_ms(datetime.fromisoformat(timestamp).timestamp())
+                timestamp_to_ms(to_timestamp(datetime.fromisoformat(timestamp)))
             except ValueError:
                 six.raise_from(ValueError("`timestamp` must be in ISO 8601 format,"
                                           " e.g. \"2017-10-30T00:44:16+00:00\""),
@@ -345,7 +365,7 @@ def now():
         Current Unix timestamp in milliseconds.
 
     """
-    return timestamp_to_ms(datetime.now().timestamp())
+    return timestamp_to_ms(to_timestamp(datetime.now()))
 
 
 def get_env_dependencies():

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1780,7 +1780,8 @@ class ExperimentRun:
                     warnings.warn("the image being logged is blank")
                 image.save(bytestream, 'png')
 
-        if bytestream.getbuffer().nbytes:
+        bytestream.seek(0)
+        if bytestream.read(1):
             bytestream.seek(0)
             image = bytestream
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1104,6 +1104,8 @@ class ExperimentRun:
         -------
         str or bytes
             Filesystem path or bytes representing the artifact.
+        bool
+            True if the artifact was only logged as its filesystem path.
 
         """
         # get key-path from ModelDB
@@ -1119,14 +1121,14 @@ class ExperimentRun:
         if artifact is None:
             raise KeyError("no artifact found with key {}".format(key))
         if artifact.path_only:
-            return artifact.path
+            return artifact.path, artifact.path_only
         else:
             # download artifact from artifact store
             url = self._get_url_for_artifact(key, "GET")
             response = requests.get(url)
             response.raise_for_status()
 
-            return response.content
+            return response.content, artifact.path_only
 
     def log_tag(self, tag):
         """
@@ -1582,8 +1584,8 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
-        dataset = self._get_artifact(key)
-        if isinstance(dataset, six.string_types):
+        dataset, path_only = self._get_artifact(key)
+        if path_only:
             return dataset
         else:
             try:
@@ -1739,8 +1741,8 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
-        model = self._get_artifact(key)
-        if isinstance(model, six.string_types):
+        model, path_only = self._get_artifact(key)
+        if path_only:
             return model
         else:
             return _artifact_utils.deserialize_model(model)
@@ -1827,8 +1829,8 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
-        image = self._get_artifact(key)
-        if isinstance(image, six.string_types):
+        image, path_only = self._get_artifact(key)
+        if path_only:
             return image
         else:
             try:
@@ -1897,8 +1899,8 @@ class ExperimentRun:
         """
         _utils.validate_flat_key(key)
 
-        artifact = self._get_artifact(key)
-        if isinstance(artifact, six.string_types):
+        artifact, path_only = self._get_artifact(key)
+        if path_only:
             return artifact
         else:
             try:


### PR DESCRIPTION
## Changelog
- remove a list-unpacked argument from a test function because Python 2 doesn't support that syntax
- implement `to_timestamp()`, because Python2 doesn't have `datetime::datetime.timestamp()`
- use `seek()` then `read()`, because Python 2's `StringIO` doesn't implement `getbuffer()`
- read `path_only` on artifact gets, because Python 2 doesn't have a bytestring type, and therefore "bytestrings" were being interpreted as paths and were not being deserialized for the user.