### PR TITLE
1116: Make dataset_df an optional parameter in log_model_for_deployment()

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1593,7 +1593,7 @@ class ExperimentRun:
             except pickle.UnpicklingError:
                 return six.BytesIO(dataset)
 
-    def log_model_for_deployment(self, model, dataset_csv, requirements, model_api):
+    def log_model_for_deployment(self, model, model_api, requirements, dataset_csv):
         """
         Logs a model artifact, a dataset CSV, requirements, and a model API to deploy on Verta.
 
@@ -1605,6 +1605,16 @@ class ExperimentRun:
             and uploaded as an artifact.
             - If file-like, then the contents will be read as bytes and uploaded as an artifact.
             - Otherwise, the object will be serialized and uploaded as an artifact.
+        model_api : str or file-like
+            Model API, specifying model deployment and predictions.
+            - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
+            and uploaded as an artifact.
+            - If file-like, then the contents will be read as bytes and uploaded as an artifact.
+        requirements : str or file-like
+            pip requirements file specifying packages necessary to deploy the model.
+            - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
+            and uploaded as an artifact.
+            - If file-like, then the contents will be read as bytes and uploaded as an artifact.
         dataset_csv : str or file-like or object
             Dataset CSV or some representation thereof.
             - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
@@ -1612,39 +1622,25 @@ class ExperimentRun:
             - If file-like, then the contents will be read as bytes and uploaded as an artifact.
             - If a pandas DataFrame, then it will be converted into a CSV and uploaded as an artifact.
             - Otherwise, the object will be serialized and uploaded as an artifact.
-        requirements : str or file-like
-            pip requirements file specifying packages necessary to deploy the model.
-            - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
-            and uploaded as an artifact.
-            - If file-like, then the contents will be read as bytes and uploaded as an artifact.
-        model_api : str or file-like
-            Model API, specifying model deployment and predictions.
-            - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
-            and uploaded as an artifact.
-            - If file-like, then the contents will be read as bytes and uploaded as an artifact.
 
         """
         # open files
         if isinstance(model, six.string_types):
             model = open(model, 'rb')
-        if isinstance(dataset_csv, six.string_types):
-            dataset_csv = open(dataset_csv, 'rb')
-        if isinstance(requirements, six.string_types):
-            requirements = open(requirements, 'rb')
         if isinstance(model_api, six.string_types):
             model_api = open(model_api, 'rb')
+        if isinstance(requirements, six.string_types):
+            requirements = open(requirements, 'rb')
+        if isinstance(dataset_csv, six.string_types):
+            dataset_csv = open(dataset_csv, 'rb')
 
         # prehandle model
         model, method, model_type = _artifact_utils.serialize_model(model)
         if method is None:
             raise ValueError("will not be able to deploy model due to unknown serialization method")
 
-        # prehandle dataset_csv
-        if hasattr(dataset_csv, 'to_csv'):  # if `dataset_csv` is a DataFrame
-            stringstream = six.StringIO()
-            dataset_csv.to_csv(stringstream, index=False)  # write as CSV
-            stringstream.seek(0)
-            dataset_csv = stringstream
+        # prehandle model_api
+        # TODO: add model serialization info to model_api
 
         # prehandle requirements
         _artifact_utils.validate_requirements_txt(requirements)
@@ -1668,13 +1664,17 @@ class ExperimentRun:
             # recreate stream
             requirements = six.BytesIO(six.ensure_binary('\n'.join(req_deps)))
 
-        # prehandle model_api
-        # TODO: add model serialization info to model_api
+        # prehandle dataset_csv
+        if hasattr(dataset_csv, 'to_csv'):  # if `dataset_csv` is a DataFrame
+            stringstream = six.StringIO()
+            dataset_csv.to_csv(stringstream, index=False)  # write as CSV
+            stringstream.seek(0)
+            dataset_csv = stringstream
 
         self._log_artifact("model.pkl", model, _CommonService.ArtifactTypeEnum.MODEL)
-        self._log_artifact("train_data", dataset_csv, _CommonService.ArtifactTypeEnum.DATA)
-        self._log_artifact("requirements.txt", requirements, _CommonService.ArtifactTypeEnum.BLOB)
         self._log_artifact("model_api.json", model_api, _CommonService.ArtifactTypeEnum.BLOB)
+        self._log_artifact("requirements.txt", requirements, _CommonService.ArtifactTypeEnum.BLOB)
+        self._log_artifact("train_data", dataset_csv, _CommonService.ArtifactTypeEnum.DATA)
 
 
     def log_model(self, key, model):

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1593,7 +1593,7 @@ class ExperimentRun:
             except pickle.UnpicklingError:
                 return six.BytesIO(dataset)
 
-    def log_model_for_deployment(self, model, dataset_csv, requirements, model_api=None):
+    def log_model_for_deployment(self, model, dataset_csv, requirements, model_api):
         """
         Logs a model artifact, a dataset CSV, requirements, and a model API to deploy on Verta.
 
@@ -1617,13 +1617,11 @@ class ExperimentRun:
             - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
             and uploaded as an artifact.
             - If file-like, then the contents will be read as bytes and uploaded as an artifact.
-        model_api : str or file-like, optional
-            Model API, specifying model deployment and predictions. If one is not provided, the client
-            will try its best to generate one based on `dataset_csv`.
+        model_api : str or file-like
+            Model API, specifying model deployment and predictions.
             - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
             and uploaded as an artifact.
             - If file-like, then the contents will be read as bytes and uploaded as an artifact.
-            - If not provided, then one will be generated based on `dataset_csv`.
 
         """
         # open files
@@ -1671,8 +1669,7 @@ class ExperimentRun:
             requirements = six.BytesIO(six.ensure_binary('\n'.join(req_deps)))
 
         # prehandle model_api
-        if model_api is None:
-            model_api = _artifact_utils.generate_model_api(dataset_csv, method, model_type)
+        # TODO: add model serialization info to model_api
 
         self._log_artifact("model.pkl", model, _CommonService.ArtifactTypeEnum.MODEL)
         self._log_artifact("train_data", dataset_csv, _CommonService.ArtifactTypeEnum.DATA)

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1593,7 +1593,7 @@ class ExperimentRun:
             except pickle.UnpicklingError:
                 return six.BytesIO(dataset)
 
-    def log_model_for_deployment(self, model, model_api, requirements, dataset_df):
+    def log_model_for_deployment(self, model, model_api, requirements, dataset_df=None):
         """
         Logs a model artifact, a dataset CSV, requirements, and a model API to deploy on Verta.
 
@@ -1615,7 +1615,7 @@ class ExperimentRun:
             - If str, then it will be interpreted as a filesystem path, its contents read as bytes,
             and uploaded as an artifact.
             - If file-like, then the contents will be read as bytes and uploaded as an artifact.
-        dataset_df : pd.DataFrame or str or file-like
+        dataset_df : pd.DataFrame or str or file-like, optional
             Dataset DataFrame or CSV file.
             - If a pandas DataFrame, then it will be converted into a CSV and uploaded as an artifact.
             - If str, then it will be interpreted as a filesystem path, its contents interpreted
@@ -1674,7 +1674,8 @@ class ExperimentRun:
         self._log_artifact("model.pkl", model, _CommonService.ArtifactTypeEnum.MODEL)
         self._log_artifact("model_api.json", model_api, _CommonService.ArtifactTypeEnum.BLOB)
         self._log_artifact("requirements.txt", requirements, _CommonService.ArtifactTypeEnum.BLOB)
-        self._log_artifact("train_data", dataset_df, _CommonService.ArtifactTypeEnum.DATA)
+        if dataset_df is not None:
+            self._log_artifact("train_data", dataset_df, _CommonService.ArtifactTypeEnum.DATA)
 
 
     def log_model(self, key, model):

--- a/workflows/demos/census-end-to-end.ipynb
+++ b/workflows/demos/census-end-to-end.ipynb
@@ -209,7 +209,7 @@
     "    print(\"Validation accuracy: {:.4f}\".format(val_acc))\n",
     "    \n",
     "    # save and log model\n",
-    "    run.log_model_for_deployment(model, df_train, \"../requirements.txt\")\n",
+    "    run.log_model_for_deployment(model, \"model_api.json\", \"../requirements.txt\", df_train)\n",
     "    \n",
     "with Pool() as pool:\n",
     "    pool.map(run_experiment, hyperparam_sets)"

--- a/workflows/examples/sklearn.ipynb
+++ b/workflows/examples/sklearn.ipynb
@@ -301,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_run.log_model_for_deployment(model, df, \"../requirements.txt\")"
+    "best_run.log_model_for_deployment(model, \"model_api.json\", \"../requirements.txt\", df)"
    ]
   },
   {

--- a/workflows/examples/tensorflow.ipynb
+++ b/workflows/examples/tensorflow.ipynb
@@ -376,7 +376,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run.log_model_for_deployment(model, df, \"../requirements.txt\")"
+    "run.log_model_for_deployment(model, \"model_api.json\", \"../requirements.txt\", df)"
    ]
   },
   {

--- a/workflows/examples/xgboost.ipynb
+++ b/workflows/examples/xgboost.ipynb
@@ -297,7 +297,7 @@
    },
    "outputs": [],
    "source": [
-    "best_run.log_model_for_deployment(model, df, \"../requirements.txt\")"
+    "best_run.log_model_for_deployment(model, \"model_api.json\", \"../requirements.txt\", df)"
    ]
   },
   {


### PR DESCRIPTION
## Changelog
- basically just switch the positions of the dataset and the model API in `log_model_for_deployment()`'s parameters
## Notes
This is a breaking change, though minor. The order of `log_model_for_deployment()`'s parameters is now different. Once this PR is merged—along with a near-future PR for generating the model API—examples and documentation have to be updated to reflect this and the use of the model API generation utility.