### PR TITLE
1117: Implement utility to check for exact version pins in a requirements.txt

### DIFF
--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -193,6 +193,30 @@ def deserialize_model(bytestring):
     return bytestream
 
 
+def validate_requirements_txt(requirements):
+    """
+    Checks that all dependencies listed in `requirements` have an exact version pin.
+
+    Parameters
+    ----------
+    requirements : file-like
+        pip requirements file.
+
+    Raises
+    ------
+    ValueError
+        If a listed dependency does not have an exact version pin.
+
+    """
+    reset_stream(requirements)  # reset cursor to beginning in case user forgot
+    contents = requirements.read()
+    reset_stream(requirements)  # reset cursor to beginning as a courtesy
+
+    for dependency in six.ensure_str(contents).split("\n"):
+        if '==' not in dependency:
+            raise ValueError("dependency '{}' must have an exact version pin".format(dependency))
+
+
 def generate_model_api(data, serialization_method, model_type, num_outputs=1):
     """
     Generates the model API JSON from a model and data.

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1649,6 +1649,7 @@ class ExperimentRun:
             dataset_csv = stringstream
 
         # prehandle requirements
+        _artifact_utils.validate_requirements_txt(requirements)
         if method == "cloudpickle":  # if cloudpickle used, add to requirements
             # remove cloudpickle from requirements if present
             req_deps = six.ensure_str(requirements.read()).splitlines()


### PR DESCRIPTION
Verifies that all dependencies listed in a requirements-file-format file-like object have an exact version pin, i.e. `==` and not e.g. `>=`.

This is of practical importance for reproducible/reliable deployment. The onus is on the user to make sure they know what Python environment is necessary to successfully build their model.