### PR TITLE
1182: Support logging lists and dictionaries as attributes

### DIFF
--- a/verta/tests/test_metadata.py
+++ b/verta/tests/test_metadata.py
@@ -82,6 +82,20 @@ class TestHyperparameters:
 
         assert experiment_run.get_hyperparameters() == self.hyperparameters
 
+    def test_log_collection(self, experiment_run):
+        with pytest.raises(TypeError):  # single fn, list
+            experiment_run.log_hyperparameter(utils.gen_str(), utils.gen_list())
+
+        with pytest.raises(TypeError):  # batch fn, list
+            experiment_run.log_hyperparameters({utils.gen_str(): utils.gen_list()})
+
+        with pytest.raises(TypeError):  # single fn, dict
+            experiment_run.log_hyperparameter(utils.gen_str(), utils.gen_dict())
+
+        with pytest.raises(TypeError):  # batch fn, dict
+            experiment_run.log_hyperparameters({utils.gen_str(): utils.gen_dict()})
+
+
 
 class TestAttributes:
     attributes = {
@@ -135,6 +149,27 @@ class TestAttributes:
                 })
 
         assert experiment_run.get_attributes() == self.attributes
+
+    def test_log_collection(self, experiment_run):
+        # single fn, list
+        key, value = utils.gen_str(), utils.gen_list()
+        experiment_run.log_attribute(key, value)
+        assert experiment_run.get_attribute(key) == value
+
+        # batch fn, list
+        key, value = utils.gen_str(), utils.gen_list()
+        experiment_run.log_attributes({key: value})
+        assert experiment_run.get_attribute(key) == value
+
+        # single fn, dict
+        key, value = utils.gen_str(), utils.gen_dict()
+        experiment_run.log_attribute(key, value)
+        assert experiment_run.get_attribute(key) == value
+
+        # batch fn, dict
+        key, value = utils.gen_str(), utils.gen_dict()
+        experiment_run.log_attributes({key: value})
+        assert experiment_run.get_attribute(key) == value
 
 
 class TestMetrics:
@@ -190,6 +225,19 @@ class TestMetrics:
 
         assert experiment_run.get_metrics() == self.metrics
 
+    def test_log_collection(self, experiment_run):
+        with pytest.raises(TypeError):  # single fn, list
+            experiment_run.log_metric(utils.gen_str(), utils.gen_list())
+
+        with pytest.raises(TypeError):  # batch fn, list
+            experiment_run.log_metrics({utils.gen_str(): utils.gen_list()})
+
+        with pytest.raises(TypeError):  # single fn, dict
+            experiment_run.log_metric(utils.gen_str(), utils.gen_dict())
+
+        with pytest.raises(TypeError):  # batch fn, dict
+            experiment_run.log_metrics({utils.gen_str(): utils.gen_dict()})
+
 
 class TestObservations:
     observations = {
@@ -211,3 +259,10 @@ class TestObservations:
 
         assert {key: [obs_val for obs_val, _ in obs_seq]
                 for key, obs_seq in experiment_run.get_observations().items()} == self.observations
+
+    def test_log_collection(self, experiment_run):
+        with pytest.raises(TypeError):  # single fn, list
+            experiment_run.log_observation(utils.gen_str(), utils.gen_list())
+
+        with pytest.raises(TypeError):  # single fn, dict
+            experiment_run.log_observation(utils.gen_str(), utils.gen_dict())

--- a/verta/tests/test_metadata.py
+++ b/verta/tests/test_metadata.py
@@ -113,15 +113,15 @@ class TestAttributes:
 
         assert experiment_run.get_attributes() == self.attributes
 
-    # def test_conflict(self, experiment_run):
-    #     for key, val in six.viewitems(self.attributes):
-    #         experiment_run.log_attribute(key, val)
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_attribute(key, val)
+    def test_conflict(self, experiment_run):
+        for key, val in six.viewitems(self.attributes):
+            experiment_run.log_attribute(key, val)
+            with pytest.raises(ValueError):
+                experiment_run.log_attribute(key, val)
 
-    #     for key, val in reversed(list(six.viewitems(self.attributes))):
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_attribute(key, val)
+        for key, val in reversed(list(six.viewitems(self.attributes))):
+            with pytest.raises(ValueError):
+                experiment_run.log_attribute(key, val)
 
     def test_atomic(self, experiment_run):
         """Test if batch completely fails even if only a single key conflicts."""

--- a/verta/tests/utils.py
+++ b/verta/tests/utils.py
@@ -8,14 +8,12 @@ import verta._utils
 from hypothesis import strategies as st
 
 
-def gen_str(length=8):
-    return ''.join([chr(random.randrange(97, 123))
-                    for _
-                    in range(length)])
+def gen_none():
+    return None
 
 
-def gen_int(start=10, stop=None):
-    return random.randrange(start, stop)
+def gen_bool():
+    return random.random() > .5
 
 
 def gen_float(start=1, stop=None):
@@ -23,6 +21,31 @@ def gen_float(start=1, stop=None):
         return random.random()*start
     else:
         return random.uniform(start, stop)
+
+
+def gen_int(start=10, stop=None):
+    return random.randrange(start, stop)
+
+
+def gen_str(length=8):
+    return ''.join([chr(random.randrange(97, 123))
+                    for _
+                    in range(length)])
+
+
+def gen_list(length=8):
+    """Generates a list with mixed-type elements."""
+    gen_el = lambda fns=(gen_none, gen_bool, gen_float, gen_int, gen_str): random.choice(fns)()
+    return [gen_el() for _ in range(length)]
+
+
+def gen_dict(length=8):
+    """Generates a single-level dict with string keys and mixed-type values."""
+    gen_val = lambda fns=(gen_none, gen_bool, gen_float, gen_int, gen_str): random.choice(fns)()
+    res = {}
+    while len(res) < length:
+        res[gen_str()] = gen_val()
+    return res
 
 
 @st.composite

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -137,9 +137,12 @@ def python_to_val_proto(val, allow_collection=False):
                 list_value.extend(val)
                 return Value(list_value=list_value)
             else:  # isinstance(val, dict)
-                struct_value = Struct()
-                struct_value.update(val)
-                return Value(struct_value=struct_value)
+                if all([isinstance(key, six.string_types) for key in val.keys()]):
+                    struct_value = Struct()
+                    struct_value.update(val)
+                    return Value(struct_value=struct_value)
+                else:  # protobuf's fault
+                    raise TypeError("struct keys must be strings; consider using log_artifact() instead")
         else:
             raise TypeError("unsupported type {}; consider using log_attribute() instead".format(type(val)))
     else:

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -113,7 +113,8 @@ def python_to_val_proto(val, allow_collection=False):
     val : one of {None, bool, float, int, str, list, dict}
         Python variable.
     allow_collection : bool, default False
-        Whether to allow ``list``s and ``dict``s as `val`.
+        Whether to allow ``list``s and ``dict``s as `val`. This flag exists because some callers
+        ought to not support logging collections, so this function will perform the typecheck on `val`.
 
     Returns
     -------

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1293,13 +1293,13 @@ class ExperimentRun:
         ----------
         key : str
             Name of the attribute.
-        value : one of {None, bool, float, int, str}
+        value : one of {None, bool, float, int, str, list, dict}
             Value of the attribute.
 
         """
         _utils.validate_flat_key(key)
 
-        attribute = _CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
+        attribute = _CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
         msg = _ExperimentRunService.LogAttribute(id=self.id, attribute=attribute)
         data = _utils.proto_to_json(msg)
         response = _utils.make_request("POST",
@@ -1319,7 +1319,7 @@ class ExperimentRun:
 
         Parameters
         ----------
-        attributes : dict of str to {None, bool, float, int, str}
+        attributes : dict of str to {None, bool, float, int, str, list, dict}
             Attributes.
 
         """
@@ -1330,7 +1330,7 @@ class ExperimentRun:
         # build KeyValues
         attribute_keyvals = []
         for key, value in six.viewitems(attributes):
-            attribute_keyvals.append(_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value)))
+            attribute_keyvals.append(_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True)))
 
         msg = _ExperimentRunService.LogAttributes(id=self.id, attributes=attribute_keyvals)
         data = _utils.proto_to_json(msg)


### PR DESCRIPTION
## Changelog
- enable conflict testing for attribute logging
  - I disabled this a while back because at the time it wasn't implemented, but it looks like it's there now!
- implement composite `hypothesis` strategies for key-values
  - These are not currently being used because `hypothesis` doesn't work well with our integration tests, but I'm putting them in this PR since they were implemented anyway.
- enable converting Python `list`s and `dict`s into protobuf `Value` Messages and vice versa
  - Through the Client API, this is only enabled for attributes.

## Notes
This actually requires **no** backend changes. For logging metadata, the backend currently [passes the inbound Message](https://github.com/VertaAI/verta-backend/blob/development/src/main/java/com/mitdbg/modeldb/experimentRun/ExperimentRunDAOMongoImpl.java#L711) to be [parsed into a JSON string](https://github.com/VertaAI/verta-backend/blob/development/src/main/java/com/mitdbg/modeldb/ModelDBUtils.java#L42) before it's then [parsed into a Mongo document](https://github.com/VertaAI/verta-backend/blob/development/src/main/java/com/mitdbg/modeldb/experimentRun/ExperimentRunDAOMongoImpl.java#L712). In other words, the backend currently has no specialized logic to handle particular value types; Google's and Mongo's provided utilities take care of it.

If you remember there being such logic, you are probably thinking of our implementation of [metadata-based find](https://github.com/VertaAI/verta-backend/blob/development/src/main/java/com/mitdbg/modeldb/experimentRun/ExperimentRunDAOMongoImpl.java#L1131), which is a separate design question. What does it mean to find by observations when observations are a list? How should we map inequality operators to collection comparisons?