### PR TITLE
1210: Use cloudpickle.__version__ instead of pip freeze for requirements.txt 

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -382,14 +382,15 @@ def get_python_version():
     return '.'.join(map(str, sys.version_info[:3]))
 
 
-def get_env_dependencies():
-    """
-    Returns a list of packages present in the current Python environment.
+# TODO: support pip3 and conda
+# def get_env_dependencies():
+#     """
+#     Returns a list of packages present in the current Python environment.
 
-    Returns
-    -------
-    dependencies : list of str
-        Names of packages and their pinned version numbers in the current Python environment.
+#     Returns
+#     -------
+#     dependencies : list of str
+#         Names of packages and their pinned version numbers in the current Python environment.
 
-    """
-    return six.ensure_str(subprocess.check_output(["pip", "freeze"])).splitlines()
+#     """
+#     return six.ensure_str(subprocess.check_output(["pip", "freeze"])).splitlines()

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1672,10 +1672,15 @@ class ExperimentRun:
             cloudpickle_dep = "cloudpickle=={}".format(_artifact_utils.cloudpickle.__version__)
             req_deps = six.ensure_str(requirements.read()).splitlines()
             _artifact_utils.reset_stream(requirements)  # reset cursor to beginning as a courtesy
-            for i, req_dep in enumerate(req_deps):
-                if req_dep.startswith("cloudpickle"):  # if present, replace
-                    req_deps[i] = cloudpickle_dep
-                    break
+            for req_dep in req_deps:
+                if req_dep.startswith("cloudpickle"):  # if present, check version
+                    our_ver = cloudpickle_dep.lstrip("cloudpickle==")
+                    their_ver = req_dep.lstrip("cloudpickle==")
+                    if our_ver != their_ver:  # versions conflict, so raise exception
+                        raise ValueError("Client is running with cloudpickle v{}, but the provided requirements specify v{}; "
+                                         "these must match".format(our_ver, their_ver))
+                    else:  # versions match, so proceed
+                        break
             else:  # if not present, add
                 req_deps.append(cloudpickle_dep)
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1669,21 +1669,15 @@ class ExperimentRun:
         _artifact_utils.reset_stream(requirements)  # reset cursor to beginning in case user forgot
         _artifact_utils.validate_requirements_txt(requirements)
         if method == "cloudpickle":  # if cloudpickle used, add to requirements
-            # remove cloudpickle from requirements if present
+            cloudpickle_dep = "cloudpickle=={}".format(_artifact_utils.cloudpickle.__version__)
             req_deps = six.ensure_str(requirements.read()).splitlines()
             _artifact_utils.reset_stream(requirements)  # reset cursor to beginning as a courtesy
             for i, req_dep in enumerate(req_deps):
-                if req_dep.startswith("cloudpickle"):
-                    del req_deps[i]
+                if req_dep.startswith("cloudpickle"):  # if present, replace
+                    req_deps[i] = cloudpickle_dep
                     break
-
-            # grab cloudpickle version from environment
-            for env_dep in _utils.get_env_dependencies():
-                if env_dep.startswith("cloudpickle"):
-                    cloudpickle_dep = env_dep
-
-            # add cloudpickle to requirements
-            req_deps.append(cloudpickle_dep)
+            else:  # if not present, add
+                req_deps.append(cloudpickle_dep)
 
             # recreate stream
             requirements = six.BytesIO(six.ensure_binary('\n'.join(req_deps)))

--- a/workflows/demos/census-end-to-end.ipynb
+++ b/workflows/demos/census-end-to-end.ipynb
@@ -88,6 +88,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
+    "import sklearn\n",
     "from sklearn import model_selection\n",
     "from sklearn import linear_model\n",
     "from sklearn import metrics"
@@ -238,8 +239,7 @@
     "    \n",
     "    # create deployment artifacts\n",
     "    model_api = ModelAPI(X_train, y_train)\n",
-    "    requirements = six.StringIO('\\n'.join([\"scikit-learn==0.21.1\",\n",
-    "                                           \"cloudpickle==1.1.1\"]))\n",
+    "    requirements = six.StringIO(\"scikit-learn=={}\".format(sklearn.__version__))\n",
     "    \n",
     "    # save and log model\n",
     "    run.log_model_for_deployment(model, model_api, requirements, X_train, y_train)\n",

--- a/workflows/examples/sklearn.ipynb
+++ b/workflows/examples/sklearn.ipynb
@@ -81,6 +81,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
+    "import sklearn\n",
     "from sklearn import datasets\n",
     "from sklearn import linear_model\n",
     "from sklearn import metrics\n",
@@ -306,8 +307,7 @@
    "source": [
     "# create deployment artifacts\n",
     "model_api = ModelAPI(X, y)\n",
-    "requirements = six.StringIO('\\n'.join([\"scikit-learn==0.21.1\",\n",
-    "                                       \"cloudpickle==1.1.1\"]))\n",
+    "requirements = six.StringIO(\"scikit-learn=={}\".format(sklearn.__version__))\n",
     "\n",
     "best_run.log_model_for_deployment(model, model_api, requirements)"
    ]

--- a/workflows/examples/tensorflow.ipynb
+++ b/workflows/examples/tensorflow.ipynb
@@ -379,8 +379,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# create deployment artifacts\n",
     "model_api = ModelAPI(X, y)\n",
-    "requirements = six.StringIO('\\n'.join([\"tensorflow==1.13.1\"]))\n",
+    "requirements = six.StringIO(\"tensorflow=={}\".format(tf.__version__))\n",
     "\n",
     "run.log_model_for_deployment(model, model_api, requirements)"
    ]

--- a/workflows/examples/xgboost.ipynb
+++ b/workflows/examples/xgboost.ipynb
@@ -303,8 +303,7 @@
    "source": [
     "# create deployment artifacts\n",
     "model_api = ModelAPI(X, y)\n",
-    "requirements = six.StringIO('\\n'.join([\"xgboost==0.90\",\n",
-    "                                       \"cloudpickle==1.1.1\"]))\n",
+    "requirements = six.StringIO(\"xgboost=={}\".format(xgb.__version__))\n",
     "\n",
     "best_run.log_model_for_deployment(model, model_api, requirements)"
    ]


### PR DESCRIPTION
## Changelog
- remove `verta._utils.get_env_dependencies` until further notice
- use `cloudpickle.__version__` to obtain its version number instead of `pip freeze`
- raise an error if `cloudpickle.__version__` doesn't match the version specified in the provided requirements
## Notes
Previously, we relied on `pip freeze` to get us the `cloudpickle` version that the Client used to serialize the model. Unfortunately, this fails when the user's environment is using pip3 or conda. Fortunately, `cloudpickle` provides a `__version__` attribute that we can use instead!