### PR TITLE
Enable logging attrs colles on client.set_*()

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -405,7 +405,7 @@ class Project:
         scheme = "http" if auth is None else "https"
 
         if attrs is not None:
-            attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
+            attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
                      for key, value in six.viewitems(attrs)]
 
         Message = _ProjectService.CreateProject
@@ -556,7 +556,7 @@ class Experiment:
         scheme = "http" if auth is None else "https"
 
         if attrs is not None:
-            attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
+            attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
                      for key, value in six.viewitems(attrs)]
 
         Message = _ExperimentService.CreateExperiment
@@ -1039,7 +1039,7 @@ class ExperimentRun:
         scheme = "http" if auth is None else "https"
 
         if attrs is not None:
-            attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value))
+            attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
                      for key, value in six.viewitems(attrs)]
 
         Message = _ExperimentRunService.CreateExperimentRun


### PR DESCRIPTION
I had enabled logging collections as attributes in #1182, but this was not enabled on the `attrs` parameter on, say, `client.set_experiment_run()`. This PR fixes that.
## Notes
Currently, logging attributes directly on Projects and Experiments is completely meaningless (as it's not supported in the UI, nor are `get_attribute()` functions in the Client), but I already supported an `attrs` parameter in their `client.set_*()` functions so I may as well support collections through them.