### PR TITLE
Implement example PyTorch notebook w/ Verta integration

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -164,7 +164,25 @@ def val_proto_to_python(msg):
         Python variable represented by `msg`.
 
     """
-    return proto_to_json(msg)
+    value_kind = msg.WhichOneof("kind")
+    if value_kind == "null_value":
+        return None
+    elif value_kind == "bool_value":
+        return msg.bool_value
+    elif value_kind == "number_value":
+        return int(msg.number_value) if msg.number_value.is_integer() else msg.number_value
+    elif value_kind == "string_value":
+        return msg.string_value
+    elif value_kind == "list_value":
+        return [val_proto_to_python(val_msg)
+                for val_msg
+                in msg.list_value.values]
+    elif value_kind == "struct_value":
+        return {key: val_proto_to_python(val_msg)
+                for key, val_msg
+                in msg.struct_value.fields.items()}
+    else:
+        raise NotImplementedError("retrieved value type is not supported")
 
 
 def unravel_key_values(rpt_key_value_msg):

--- a/workflows/examples/pytorch.ipynb
+++ b/workflows/examples/pytorch.ipynb
@@ -1,0 +1,377 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Single Fully-Connected Network (PyTorch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/VertaAI/modeldb-client/blob/master/workflows/examples/pytorch.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# restart your notebook if prompted on Colab\n",
+    "try:\n",
+    "    import verta\n",
+    "except ModuleNotFoundError:\n",
+    "    !pip install verta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example features:\n",
+    "- **PyTorch** fully-connected neural network\n",
+    "- **PyTorch**'s `DataSet` utility for batching training data\n",
+    "- **verta**'s Python client logging training results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HOST = \"demo.app.verta.ai\"\n",
+    "\n",
+    "PROJECT_NAME = \"MNIST Multiclassification\"\n",
+    "EXPERIMENT_NAME = \"FC-NN\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#import os\n",
+    "#os.environ['VERTA_EMAIL'] = \n",
+    "#os.environ['VERTA_DEV_KEY'] = "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import six\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn import datasets\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as func\n",
+    "import torch.optim as optim\n",
+    "import torch.utils.data as data_utils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Log Workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = datasets.load_digits()\n",
+    "\n",
+    "X = data['data']\n",
+    "y = data['target']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(np.hstack((X, y.reshape(-1, 1))),\n",
+    "                  columns=[\"pixel_{}\".format(i) for i in range(X.shape[-1])] + ['digit'])\n",
+    "\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# gather indices to split training data into training and validation sets\n",
+    "shuffled_idxs = np.random.permutation(len(y))\n",
+    "idxs_train = shuffled_idxs[int(len(shuffled_idxs)/10):]  # last 90%\n",
+    "idxs_val = shuffled_idxs[:int(len(shuffled_idxs)/10)]  # first 10%\n",
+    "\n",
+    "X_train, y_train = (torch.tensor(X[idxs_train], dtype=torch.float),\n",
+    "                    torch.tensor(y[idxs_train], dtype=torch.long))\n",
+    "X_val, y_val = (torch.tensor(X[idxs_val], dtype=torch.float),\n",
+    "                torch.tensor(y[idxs_val], dtype=torch.long))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create Dataset object to support batch training\n",
+    "class TrainingDataset(data_utils.Dataset):\n",
+    "    def __init__(self, features, labels):\n",
+    "        self.features = features\n",
+    "        self.labels = labels\n",
+    "        \n",
+    "    def __len__(self):\n",
+    "        return len(self.labels)\n",
+    "    \n",
+    "    def __getitem__(self, idx):\n",
+    "        return (self.features[idx], self.labels[idx])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instantiate Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from verta import Client\n",
+    "from verta.utils import ModelAPI\n",
+    "\n",
+    "client = Client(HOST)\n",
+    "proj = client.set_project(PROJECT_NAME)\n",
+    "expt = client.set_experiment(EXPERIMENT_NAME)\n",
+    "run = client.set_experiment_run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.log_hyperparameter(\"hidden_size\", 512)\n",
+    "run.log_hyperparameter(\"dropout\", 0.2)\n",
+    "\n",
+    "class Net(nn.Module):\n",
+    "    def __init__(self, num_features=X.shape[1],\n",
+    "                 hidden_size=run.get_hyperparameter(\"hidden_size\")):\n",
+    "        super().__init__()\n",
+    "        self.fc      = nn.Linear(num_features, hidden_size)\n",
+    "        self.dropout = nn.Dropout(run.get_hyperparameter(\"dropout\"))\n",
+    "        self.output  = nn.Linear(hidden_size, 10)\n",
+    "        \n",
+    "    def forward(self, x):\n",
+    "        x = x.view(x.shape[0], -1)  # flatten non-batch dimensions\n",
+    "        x = func.relu(self.fc(x))\n",
+    "        x = self.dropout(x)\n",
+    "        x = func.softmax(self.output(x), dim=-1)\n",
+    "        return x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare Hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# specify training procedure\n",
+    "model = Net()\n",
+    "\n",
+    "criterion = torch.nn.CrossEntropyLoss()\n",
+    "run.log_hyperparameter(\"loss_fn\", \"cross entropy\")\n",
+    "optimizer = torch.optim.Adam(model.parameters())\n",
+    "run.log_hyperparameter(\"optimizer\", \"adam\")\n",
+    "\n",
+    "run.log_hyperparameter(\"num_epochs\", 5)\n",
+    "run.log_hyperparameter(\"batch_size\", 32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run and Log Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# enable batching of training data\n",
+    "dataset = TrainingDataset(X_train, y_train)\n",
+    "dataloader = data_utils.DataLoader(dataset,\n",
+    "                                   batch_size=run.get_hyperparameter(\"batch_size\"),\n",
+    "                                   shuffle=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i_epoch in range(run.get_hyperparameter(\"num_epochs\")):\n",
+    "    for i_batch, (X_batch, y_batch) in enumerate(dataloader):\n",
+    "        model.zero_grad()  # reset model gradients\n",
+    "\n",
+    "        output = model(X_batch)  # conduct forward pass\n",
+    "\n",
+    "        loss = criterion(output, y_batch)  # compare model output w/ ground truth\n",
+    "        \n",
+    "        print(\"\\repoch {}/{} | \".format(i_epoch+1, run.get_hyperparameter(\"num_epochs\")), end='')\n",
+    "        print(\"iteration {}/{} | \".format(i_batch+1, len(dataloader)), end='')\n",
+    "        print(\"epoch loss avg: {}\".format(loss.item()), end='')\n",
+    "\n",
+    "        loss.backward()  # backpropogate loss to calculate gradients\n",
+    "        optimizer.step()  # update model weights\n",
+    "    with torch.no_grad():  # no need to calculate gradients when assessing accuracy\n",
+    "        print()\n",
+    "        \n",
+    "        pred_train = model(X_train).numpy().argmax(axis=1)\n",
+    "        train_acc = (pred_train == y_train.numpy()).mean()\n",
+    "        print(\"Training accuracy: {}\".format(train_acc))\n",
+    "        run.log_observation(\"train_acc\", train_acc)\n",
+    "        \n",
+    "        pred_val = model(X_val).numpy().argmax(axis=1)\n",
+    "        val_acc = (pred_val == y_val.numpy()).mean()\n",
+    "        print(\"Validation accuracy: {}\".format(val_acc))\n",
+    "        run.log_observation(\"val_acc\", val_acc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Calculate and Log Accuracy on Full Training Set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():  # no need to calculate gradients when assessing accuracy\n",
+    "    pred_train = model(X_train).numpy().argmax(axis=1)\n",
+    "    train_acc = (pred_train == y_train.numpy()).mean()\n",
+    "    print(\"Training accuracy: {}\".format(train_acc))\n",
+    "    run.log_metric(\"train_acc\", train_acc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Log Model for Deployment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create deployment artifacts\n",
+    "model_api = ModelAPI(X, y)\n",
+    "requirements = six.StringIO(\"torch=={}\".format(torch.__version__))\n",
+    "\n",
+    "run.log_model_for_deployment(model, model_api, requirements)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Changelog
- revise `_utils.val_proto_to_python()` to return an integer if `number_value` is an integral value
  - This is a reasonable behavior because functions that expect a `float` can often take an `int`, but functions that expect an `int` often refuse a `float`. It's more flexible to err on the side of casting integral `floats` to `int` (as witnessed in the PyTorch example notebook).
- implement an example Jupyter notebook showcasing `verta` integration

## Notes
This notebook logs artifacts for deployment at the end—in line with the other example notebooks—but we have a bit of additional work to do with our Deployment Service before PyTorch models are fully supported.