### PR TITLE
Implement Code Versioning v0

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import time
 
-from IPython.display import Javascript, display
 import requests
 from requests.adapters import HTTPAdapter
 
@@ -28,9 +27,10 @@ except ImportError:  # pandas not installed
 
 try:
     import ipykernel
-except ImportError:  # IPython not installed
+except ImportError:  # Jupyter not installed
     pass
 else:
+    from IPython.display import Javascript, display
     try:  # Python 3
         from notebook.notebookapp import list_running_servers
     except ImportError:  # Python 2
@@ -474,7 +474,7 @@ def get_notebook_filepath():
     """
     try:
         connection_file = ipykernel.connect.get_connection_file()
-    except (NameError,  # IPython not installed
+    except (NameError,  # Jupyter not installed
             RuntimeError):  # not in a Notebook
         raise OSError("unable to find notebook file")
     else:

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -444,9 +444,19 @@ def get_python_version():
     return '.'.join(map(str, sys.version_info[:3]))
 
 
-def save_notebook():
+def save_notebook(timeout=5):
     """
     Saves the current notebook and returns after the file in disk has been updated.
+
+    Parameters
+    ----------
+    timeout : float, default 5
+        Maximum number of seconds to wait for the notebook to save.
+
+    Raises
+    ------
+    OSError
+        If the notebook is not modified within `timeout` seconds.
 
     """
     notebook_name = get_notebook_filepath()
@@ -458,12 +468,14 @@ def save_notebook():
     });
     '''))
 
-    while True:
+    start_time = time.time()
+    while time.time() - start_time < timeout:
         new_modtime = os.path.getmtime(notebook_name)
         if new_modtime > modtime:
-            break
+            return
         time.sleep(0.01)
-
+    else:
+        raise OSError("unable to save notebook")
 
 def get_notebook_filepath():
     """

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -554,7 +554,11 @@ def get_script_filepath():
     for frame_info in inspect.stack():
         module = inspect.getmodule(frame_info[0])
         if module is None or module.__name__.split('.', 1)[0] != "verta":
-            return frame_info[1]
+            filepath = frame_info[1]
+            if os.path.exists(filepath):  # e.g. Jupyter fakes the filename for cells
+                return filepath
+            else:
+                break  # continuing might end up returning a built-in
     raise OSError("unable to find script file")
 
 # TODO: support pip3 and conda

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -506,10 +506,11 @@ def get_notebook_filepath():
         for server in list_running_servers():
             response = requests.get(urljoin(server['url'], 'api/sessions'),
                                     params={'token': server.get('token', '')})
-            for session in response.json():
-                if session['kernel']['id'] == kernel_id:
-                    relative_path = session['notebook']['path']
-                    return os.path.join(server['notebook_dir'], relative_path)
+            if response.ok:
+                for session in response.json():
+                    if session['kernel']['id'] == kernel_id:
+                        relative_path = session['notebook']['path']
+                        return os.path.join(server['notebook_dir'], relative_path)
     raise OSError("unable to find notebook file")
 
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2145,7 +2145,9 @@ class ExperimentRun:
             Python script or Jupyter notebook file. If no file is provided, the Client will make its
             best effort to dynamically find the script/notebook file that is calling this function.
         git_sha : str, optional
-        remote_utl : str, optional
+            Git commit hash associated with this code version.
+        remote_url : str, optional
+            URL for a remote Git repository containing `git_sha`.
 
         """
         # prehandle file

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2165,11 +2165,14 @@ class ExperimentRun:
             else:
                 _utils.save_notebook()
                 print("reading code from {}".format(filename))
-                file = open(filename, 'r')
-                while not len(file.read()):  # wait in case notebook is still saving
-                    _artifact_utils.reset_stream(file)
+                with open(filename, 'r') as f:
+                    contents = f.read()
+                while not contents:  # wait in case notebook is still saving
                     time.sleep(.01)
-                _artifact_utils.reset_stream(file)
+                    with open(filename, 'r') as f:
+                        contents = f.read()
+                else:
+                    file = six.StringIO(contents)
 
         # prehandle git_sha
         if git_sha is None:

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2149,15 +2149,17 @@ class ExperimentRun:
         """
         if isinstance(file, six.string_types):
             file = open(file, 'r')
-        if file is None:
+        elif file is None:
             try:
                 filename = _utils.get_notebook_filepath()
             except OSError:  # notebook not found
                 try:
                     filename = _utils.get_script_filepath()
                 except OSError:  # script not found
-                    pass  # TODO: raise?
+                    print("unable to find code file; skipping")
                 else:
-                    file = open(file, 'r')
+                    print("reading code from {}".format(filename))
+                    file = open(filename, 'r')
             else:
-                file = open(file, 'r')
+                print("reading code from {}".format(filename))
+                file = open(filename, 'r')

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2131,3 +2131,20 @@ class ExperimentRun:
 
         response_msg = _utils.json_to_proto(response.json(), Message.Response)
         return _utils.unravel_observations(response_msg.experiment_run.observations)
+
+    def log_code(self, file=None, git_sha=None, remote_url=None):
+        """
+        Logs a code version to this Experiment Run.
+
+        A code version consists of a group of artifacts and attributes that describe the state of code.
+
+        Parameters
+        ----------
+        file : str or file-like, optional
+            Python script or Jupyter notebook file. If no file is provided, the Client will make its
+            best effort to dynamically find the script/notebook file that is calling this function.
+        git_sha : str, optional
+        remote_utl : str, optional
+
+        """
+        pass

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2147,6 +2147,7 @@ class ExperimentRun:
         remote_utl : str, optional
 
         """
+        # prehandle file
         if isinstance(file, six.string_types):
             file = open(file, 'r')
         elif file is None:
@@ -2161,5 +2162,21 @@ class ExperimentRun:
                     print("reading code from {}".format(filename))
                     file = open(filename, 'r')
             else:
+                _utils.save_notebook()
                 print("reading code from {}".format(filename))
                 file = open(filename, 'r')
+
+        # prehandle git_sha
+        if git_sha is None:
+            pass  # TODO: find it
+
+        # prehandle remote_url
+        if remote_url is None:
+            pass  # TODO: find it
+
+        if file is not None:
+            self.log_artifact("code", file)
+        if git_sha is not None:
+            self.log_attribute("git_sha", git_sha)
+        if remote_url is not None:
+            self.log_attribute("remote_url", remote_url)

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -5,6 +5,7 @@ from six.moves.urllib.parse import urlparse
 import ast
 import os
 import re
+import time
 import warnings
 
 import PIL
@@ -2165,6 +2166,10 @@ class ExperimentRun:
                 _utils.save_notebook()
                 print("reading code from {}".format(filename))
                 file = open(filename, 'r')
+                while not len(file.read()):  # wait in case notebook is still saving
+                    _artifact_utils.reset_stream(file)
+                    time.sleep(.01)
+                _artifact_utils.reset_stream(file)
 
         # prehandle git_sha
         if git_sha is None:

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2163,15 +2163,14 @@ class ExperimentRun:
                     print("reading code from {}".format(filename))
                     file = open(filename, 'r')
             else:
-                _utils.save_notebook()
                 print("reading code from {}".format(filename))
-                with open(filename, 'r') as f:
-                    contents = f.read()
-                while not contents:  # wait in case notebook is still saving
-                    time.sleep(.01)
+                try:
+                    file = _utils.save_notebook()
+                except OSError:  # unable to save
+                    # just read it now, I guess
+                    print("unable to save notebook; reading current state instead")
                     with open(filename, 'r') as f:
                         contents = f.read()
-                else:
                     file = six.StringIO(contents)
 
         # prehandle git_sha

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2147,4 +2147,17 @@ class ExperimentRun:
         remote_utl : str, optional
 
         """
-        pass
+        if isinstance(file, six.string_types):
+            file = open(file, 'r')
+        if file is None:
+            try:
+                filename = _utils.get_notebook_filepath()
+            except OSError:  # notebook not found
+                try:
+                    filename = _utils.get_script_filepath()
+                except OSError:  # script not found
+                    pass  # TODO: raise?
+                else:
+                    file = open(file, 'r')
+            else:
+                file = open(file, 'r')


### PR DESCRIPTION
## Changelog
- [optionally import Jupyter dependencies `ipykernel` and `IPython`](https://github.com/VertaAI/modeldb-client/pull/117/files#diff-0320d7c96f347d1e665817a9d5a22f98R28)
- [create internal utility function to force-save the current Jupyter notebook (thanks Josh) and return a copy of its contents when the file is rewritten](https://github.com/VertaAI/modeldb-client/pull/117/files#diff-0320d7c96f347d1e665817a9d5a22f98R447)
- [create internal utility function to locate the current Jupyter notebook's filepath](https://github.com/VertaAI/modeldb-client/pull/117/files#diff-0320d7c96f347d1e665817a9d5a22f98R500)
- [create internal utility function to locate the current Python script's filepath](https://github.com/VertaAI/modeldb-client/pull/117/files#diff-0320d7c96f347d1e665817a9d5a22f98R537)
- [implement `run.log_code()`, which logs the source code filepath, a git SHA, and a remote repository URL](https://github.com/VertaAI/modeldb-client/pull/117/files#diff-9346abd1d99b6dc362adc8590989cab4R2136)
  - @mvartakAtVerta suggested having the function let the user know that they can manually pass in the code filepath if we fail to find it. Unfortunately, because this function isn't an atomic transaction, it would be a bit pointless (e.g. if we fail to find the notebook but successfully log the git SHA, this function cannot possibly be executed again on the same run).