### PR TITLE
Implement Option to Silence Client Connection Errors

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -49,7 +49,7 @@ def client(host, port, email, dev_key):
     yield client
 
     if client.proj is not None:
-        utils.delete_project(client.proj.id, client)
+        utils.delete_project(client.proj.id, client._conn)
 
 
 @pytest.fixture

--- a/verta/tests/test_protos.py
+++ b/verta/tests/test_protos.py
@@ -11,8 +11,8 @@ class TestGetChildren:
         for _ in range(3):
             expt_ids.append(client.set_experiment().id)
 
-        response = requests.get("http://{}/v1/experiment/getExperimentsInProject".format(client._socket),
-                                params={'project_id': proj.id}, headers=client._auth)
+        response = requests.get("http://{}/v1/experiment/getExperimentsInProject".format(client._conn.socket),
+                                params={'project_id': proj.id}, headers=client._conn.auth)
         response.raise_for_status()
         assert set(expt_ids) == set(experiment['id'] for experiment in response.json()['experiments'])
 
@@ -27,8 +27,8 @@ class TestGetChildren:
         for _ in range(3):
             run_ids.append(client.set_experiment_run().id)
 
-        response = requests.get("http://{}/v1/experiment-run/getExperimentRunsInProject".format(client._socket),
-                                params={'project_id': proj.id}, headers=client._auth)
+        response = requests.get("http://{}/v1/experiment-run/getExperimentRunsInProject".format(client._conn.socket),
+                                params={'project_id': proj.id}, headers=client._conn.auth)
         response.raise_for_status()
         assert set(run_ids) == set(experiment_run['id'] for experiment_run in response.json()['experiment_runs'])
 
@@ -40,7 +40,7 @@ class TestGetChildren:
         for _ in range(3):
             run_ids.append(client.set_experiment_run().id)
 
-        response = requests.get("http://{}/v1/experiment-run/getExperimentRunsInExperiment".format(client._socket),
-                                params={'experiment_id': expt.id}, headers=client._auth)
+        response = requests.get("http://{}/v1/experiment-run/getExperimentRunsInExperiment".format(client._conn.socket),
+                                params={'experiment_id': expt.id}, headers=client._conn.auth)
         response.raise_for_status()
         assert set(run_ids) == set(experiment_run['id'] for experiment_run in response.json()['experiment_runs'])

--- a/verta/tests/utils.py
+++ b/verta/tests/utils.py
@@ -82,19 +82,19 @@ def st_key_values(draw, min_size=1, max_size=12, scalars_only=False):
                                 max_size=max_size))
 
 
-def delete_project(id_, client):
-    request_url = "{}://{}/v1/project/deleteProject".format(client._scheme, client._socket)
-    response = requests.delete(request_url, json={'id': id_}, headers=client._auth)
+def delete_project(id_, conn):
+    request_url = "{}://{}/v1/project/deleteProject".format(conn.scheme, conn.socket)
+    response = requests.delete(request_url, json={'id': id_}, headers=conn.auth)
     response.raise_for_status()
 
 
-def delete_experiment(id_, client):
-    request_url = "{}://{}/v1/experiment/deleteExperiment".format(client._scheme, client._socket)
-    response = requests.delete(request_url, json={'id': id_}, headers=client._auth)
+def delete_experiment(id_, conn):
+    request_url = "{}://{}/v1/experiment/deleteExperiment".format(conn.scheme, conn.socket)
+    response = requests.delete(request_url, json={'id': id_}, headers=conn.auth)
     response.raise_for_status()
 
 
-def delete_experiment_run(id_, client):
-    request_url = "{}://{}/v1/experiment-run/deleteExperimentRun".format(client._scheme, client._socket)
-    response = requests.delete(request_url, json={'id': id_}, headers=client._auth)
+def delete_experiment_run(id_, conn):
+    request_url = "{}://{}/v1/experiment-run/deleteExperimentRun".format(conn.scheme, conn.socket)
+    response = requests.delete(request_url, json={'id': id_}, headers=conn.auth)
     response.raise_for_status()

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -26,7 +26,7 @@ _VALID_HTTP_METHODS = {'GET', 'POST', 'PUT', 'DELETE'}
 _VALID_FLAT_KEY_CHARS = set(string.ascii_letters + string.digits + '_-')
 
 
-def make_request(method, url, auth, retry, **kwargs):
+def make_request(method, url, auth=None, retry=None, **kwargs):
     """
     Makes a REST request.
 
@@ -36,9 +36,9 @@ def make_request(method, url, auth, retry, **kwargs):
         HTTP method.
     url : str
         URL.
-    auth : dict
+    auth : dict, optional
         Verta authentication headers.
-    retry : urllib3.util.retry.Retry
+    retry : urllib3.util.retry.Retry, optional
         Connection retry configuration.
     **kwargs
         Parameters to requests.request().
@@ -51,8 +51,12 @@ def make_request(method, url, auth, retry, **kwargs):
     if method.upper() not in _VALID_HTTP_METHODS:
         raise ValueError("`method` must be one of {}".format(_VALID_HTTP_METHODS))
 
-    # add `auth` to `kwargs['headers']`
-    kwargs.setdefault('headers', {}).update(auth)
+    if retry is None:
+        retry = 0
+
+    if auth is not None:
+        # add `auth` to `kwargs['headers']`
+        kwargs.setdefault('headers', {}).update(auth)
 
     with requests.Session() as s:
         s.mount(url, HTTPAdapter(max_retries=retry))

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -10,6 +10,7 @@ import sys
 
 import requests
 from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value, ListValue, Struct, NULL_VALUE
@@ -26,7 +27,40 @@ _VALID_HTTP_METHODS = {'GET', 'POST', 'PUT', 'DELETE'}
 _VALID_FLAT_KEY_CHARS = set(string.ascii_letters + string.digits + '_-')
 
 
-def make_request(method, url, auth=None, retry=None, ignore_conn_err=False, **kwargs):
+class Connection:
+    def __init__(self, scheme=None, socket=None, auth=None, max_retries=0, ignore_conn_err=False):
+        """
+        HTTP connection configuration utility struct.
+
+        Parameters
+        ----------
+        scheme : {'http', 'https'}, optional
+            HTTP authentication scheme.
+        socket : str, optional
+            Hostname and port.
+        auth : dict, optional
+            Verta authentication headers.
+        max_retries : int, default 0
+            Maximum number of times to retry a request on a connection failure. This only attempts retries
+            on HTTP codes {403, 503, 504} which commonly occur during back end connection lapses.
+        ignore_conn_err : bool, default False
+            Whether to ignore connection errors and instead return successes with empty contents.
+
+        """
+        self.scheme = scheme
+        self.socket = socket
+        self.auth = auth
+        # TODO: retry on 404s, but only if we're sure it's not legitimate e.g. from a GET
+        self.retry = Retry(total=max_retries,
+                           backoff_factor=1,  # each retry waits (2**retry_num) seconds
+                           method_whitelist=False,  # retry on all HTTP methods
+                           status_forcelist=(403, 503, 504),  # only retry on these status codes
+                           raise_on_redirect=False,  # return Response instead of raising after max retries
+                           raise_on_status=False)  # return Response instead of raising after max retries
+        self.ignore_conn_err = ignore_conn_err
+
+
+def make_request(method, url, conn, **kwargs):
     """
     Makes a REST request.
 
@@ -36,12 +70,8 @@ def make_request(method, url, auth=None, retry=None, ignore_conn_err=False, **kw
         HTTP method.
     url : str
         URL.
-    auth : dict, optional
-        Verta authentication headers.
-    retry : urllib3.util.retry.Retry, optional
-        Connection retry configuration.
-    ignore_conn_err : bool, default False
-        Whether to ignore a connection error and instead return a success with empty contents.
+    conn : verta._utils.Connection
+        Connection authentication and configuration.
     **kwargs
         Parameters to requests.request().
 
@@ -53,29 +83,26 @@ def make_request(method, url, auth=None, retry=None, ignore_conn_err=False, **kw
     if method.upper() not in _VALID_HTTP_METHODS:
         raise ValueError("`method` must be one of {}".format(_VALID_HTTP_METHODS))
 
-    if retry is None:
-        retry = 0
-
-    if auth is not None:
-        # add `auth` to `kwargs['headers']`
-        kwargs.setdefault('headers', {}).update(auth)
+    if conn.auth is not None:
+        # add auth to `kwargs['headers']`
+        kwargs.setdefault('headers', {}).update(conn.auth)
 
     with requests.Session() as s:
-        s.mount(url, HTTPAdapter(max_retries=retry))
+        s.mount(url, HTTPAdapter(max_retries=conn.retry))
         try:
             response = s.request(method, url, **kwargs)
-        except requests.RequestException as e:
-            if not ignore_conn_err:
+        except (requests.exceptions.BaseHTTPError,
+                requests.exceptions.RequestException) as e:
+            if not conn.ignore_conn_err:
                 raise e
         else:
-            if response.ok or not ignore_conn_err:
+            if response.ok or not conn.ignore_conn_err:
                 return response
         # fabricate response
         response = requests.Response()
         response.status_code = 200  # success
         response._content = six.ensure_binary("{}")  # empty contents
         return response
-
 
 
 def proto_to_json(msg):

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -96,7 +96,9 @@ class Client:
         # verify connection
         socket = host if port is None else "{}:{}".format(host, port)
         try:
-            response = requests.get("{}://{}/v1/project/verifyConnection".format(scheme, socket), headers=auth)
+            response = _utils.make_request("GET",
+                                           "{}://{}/v1/project/verifyConnection".format(scheme, socket),
+                                           auth)
         except requests.ConnectionError:
             six.raise_from(requests.ConnectionError("connection failed; please check `host` and `port`"),
                            None)
@@ -1142,7 +1144,7 @@ class ExperimentRun:
         # upload artifact to artifact store
         url = self._get_url_for_artifact(key, "PUT")
         artifact_stream, _ = _artifact_utils.ensure_bytestream(artifact)
-        response = requests.put(url, data=artifact_stream)
+        response = _utils.make_request("PUT", url, data=artifact_stream)
         response.raise_for_status()
 
     def _log_artifact_path(self, key, artifact_path, artifact_type):
@@ -1217,7 +1219,7 @@ class ExperimentRun:
         else:
             # download artifact from artifact store
             url = self._get_url_for_artifact(key, "GET")
-            response = requests.get(url)
+            response = _utils.make_request("GET", url)
             response.raise_for_status()
 
             return response.content, artifact.path_only


### PR DESCRIPTION
## Changelog
- add `ignore_conn_err` boolean param/attr to `Client` class
- if `ignore_conn_err`, have `_utils.make_request` return an empty successful response
- create internal utility `Connection` class to track connection configuration settings
- update pytests to use `Connection`
## Notes
This almost goes without saying, but using the Client to get data from ExperimentRuns may lead to workflow failures because instead of returning valid data, they return default values and empty collections.

Also, because successes are fabricated, various Client print statements will be lies/nonsensical, such as "connection successfully established" and "set existing Project: ". This could be remedied in the future.