### PR TITLE
Implement log_code() and get_code()

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -657,16 +657,26 @@ def get_git_commit_hash():
     raise OSError("unable to find git commit hash")
 
 
-def get_git_commit_dirtiness():
-    try:
-        diff_paths = six.ensure_str(
-            subprocess.check_output(["git", "status", "--porcelain"])
-        ).splitlines()
-    except:
-        pass
+def get_git_commit_dirtiness(commit_hash=None):
+    if commit_hash is not None:
+        try:  # compare `commit_hash` to the working tree and index
+            diffs = six.ensure_str(
+                subprocess.check_output(["git", "diff-index", commit_hash])
+            ).splitlines()
+        except:
+            pass
+        else:
+            return len(diffs) > 0
     else:
-        return not all(path.startswith("??") for path in diff_paths)
-    raise OSError("unable to find git status")
+        try:
+            diff_paths = six.ensure_str(
+                subprocess.check_output(["git", "status", "--porcelain"])
+            ).splitlines()
+        except:
+            pass
+        else:
+            return not all(path.startswith("??") for path in diff_paths)
+    raise OSError("unable to determine git commit dirtiness")
 
 
 def get_git_remote_url():

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -125,6 +125,10 @@ def make_request(method, url, conn, **kwargs):
         return response
 
 
+def is_hidden(path):  # to avoid "./".startswith('.')
+    return os.path.basename(path.rstrip('/')).startswith('.') and path != "."
+
+
 def find_filepaths(paths, extensions, include_hidden=False):
     """
     Unravels a list of file and directory paths into a list of only filepaths by walking through the
@@ -142,8 +146,6 @@ def find_filepaths(paths, extensions, include_hidden=False):
     """
     if isinstance(paths, six.string_types):
         paths = [paths]
-    # convert into absolute paths
-    paths = map(os.path.abspath, paths)
 
     if isinstance(extensions, six.string_types):
         extensions = [extensions]
@@ -155,11 +157,11 @@ def find_filepaths(paths, extensions, include_hidden=False):
     for path in paths:
         if os.path.isdir(path):
             for root, _, subpaths in os.walk(path):
-                if os.path.basename(root).startswith('.') and not include_hidden:
-                    continue
+                if is_hidden(root) and not include_hidden:
+                    continue  # skip hidden directories
                 for subpath in subpaths:
-                    if os.path.basename(subpath).startswith('.') and not include_hidden:
-                        continue
+                    if is_hidden(subpath) and not include_hidden:
+                        continue  # skip hidden files
                     if os.path.splitext(subpath)[1] in extensions:
                         filepaths.append(os.path.join(root, subpath))
         else:

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -148,7 +148,7 @@ def find_filepaths(paths, extensions, include_hidden=False):
     if isinstance(extensions, six.string_types):
         extensions = [extensions]
     # prepend period to file extensions where missing
-    extensions = map(lambda ext: ext if ext.startswith('.') else ".{}".format(ext), extensions)
+    extensions = map(lambda ext: ext if ext.startswith('.') else ('.' + ext), extensions)
     extensions = set(extensions)
 
     filepaths = []

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2241,7 +2241,7 @@ class ExperimentRun:
             #     ZipFile.write() completely drops "../" path components,
             #     so we need to resolve them by finding a common subpath to start at
             curr_dir = os.path.join(os.path.abspath(os.curdir), "")
-            paths_plus = paths + [curr_dir]
+            paths_plus = list(map(os.path.abspath, paths)) + [curr_dir]
             common_prefix = os.path.commonprefix(paths_plus)
             common_dir = os.path.dirname(common_prefix)
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2179,18 +2179,56 @@ class ExperimentRun:
 
         Examples
         --------
-        Upload the currently executing notebook/script:
+        Find and upload the currently executing notebook/script:
 
         >>> run.log_code()
+        >>> run.get_code().printdir()
+        File Name                                  Modified             Size
+        classification.ipynb                2019-07-10 17:18:24        10287
 
         Upload a specific source code file:
 
         >>> run.log_code("../trainer/training_pipeline.py")
+        >>> run.get_code().printdir()
+        File Name                                  Modified             Size
+        trainer/training_pipeline.py        2019-05-31 10:34:44          964
 
-        Log the location of the currently executing notebook/script relative to the Git repository
-        root plus snapshot information:
+        Find and log Git snapshot information, plus the location of the currently executing
+        notebook/script relative to the repository root:
 
         >>> run.log_code(use_git=True)
+        >>> run.get_code()
+        {'filepaths': ['comparison/outcomes/classification.ipynb'],
+         'remote_url': 'git@github.com:VertaAI/experiments.git',
+         'commit_hash': 'f99abcfae6c3ce6d22597f95ad6ef260d31527a6',
+         'is_dirty': False}
+
+        Find and log Git snapshot information, plus the location of a specific source code file
+        relative to the repository root:
+
+        >>> run.log_code("../trainer/training_pipeline.py", use_git=True)
+        >>> run.get_code()
+        {'filepaths': ['comparison/trainer/training_pipeline.py'],
+         'remote_url': 'git@github.com:VertaAI/experiments.git',
+         'commit_hash': 'f99abcfae6c3ce6d22597f95ad6ef260d31527a6',
+         'is_dirty': False}
+
+        Find and log Git snapshot information—overwriting the commit hash—plus the location of the
+        currently executing notebook/script relative to the repository root:
+
+        >>> run.log_code(use_git=True, commit_hash="bd16ba622d8a21ba5ede6cb021193f66efec4654")
+        >>> run.get_code()
+        {'filepaths': ['comparison/outcomes/classification.ipynb'],
+         'remote_url': 'git@github.com:VertaAI/experiments.git',
+         'commit_hash': 'bd16ba622d8a21ba5ede6cb021193f66efec4654',
+         'is_dirty': True}
+
+        Log a particular remote URL:
+
+        >>> run.log_code(remote_url="git@github.com:convoliution/experiments.git")
+        >>> run.get_code()
+        {'filepaths': [/Users/miliu/Documents/client/workflows/demos/sandbox.ipynb'],
+         'remote_url': 'git@github.com:convoliution/experiments.git'}
 
         """
         if paths is None:
@@ -2293,7 +2331,7 @@ class ExperimentRun:
         -------
         dict or zipfile.ZipFile
             Either:
-                - a dictionary containing Git snapshot information with the following items:
+                - a dictionary containing Git snapshot information with at most the following items:
                     - **filepaths** (*list of str*)
                     - **repo** (*str*) – Remote repository URL
                     - **hash** (*str*) – Commit hash

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2283,12 +2283,10 @@ class ExperimentRun:
             # obtain deepest common directory
             #     ZipFile.write() completely drops "../" path components,
             #     so we need to resolve them by finding a common subpath to start at.
-            curr_dir = os.path.join(os.path.abspath(os.curdir), "")
-            paths_plus = list(map(os.path.abspath, paths)) + [curr_dir]
             #     `commonprefix()` works character by character; if the first few characters of two
             #     different files are the same, `commonprefix()` will keep it. Therefore we have to
             #     get the actual `dirname()` of the common prefix.
-            common_prefix = os.path.commonprefix(paths_plus)
+            common_prefix = os.path.commonprefix(paths)
             common_dir = os.path.dirname(common_prefix)
 
             # write ZIP archive

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2250,10 +2250,12 @@ class ExperimentRun:
                 repo_root = _utils.get_git_repo_root_dir()
                 paths = [os.path.relpath(path, repo_root)
                          for path in paths]
-                # append trailing separator to directories
-                #     This is necessary for the `os.path.commonprefix()` part later to work properly.
-                paths = [os.path.join(path, "") if os.path.isdir(path) else path
-                         for path in paths]
+            else:
+                # adjust paths to be absolute
+                paths = map(os.path.abspath, paths)
+            # append trailing separator to directories as a courtesy
+            paths = [os.path.join(path, "") if os.path.isdir(path) else path
+                        for path in paths]
             msg.code_version.git_snapshot.filepaths.extend(paths)
 
             try:

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2151,6 +2151,7 @@ class ExperimentRun:
         with zipfile.ZipFile(bytestream, 'w') as zipf:
             for filepath in filepaths:
                 zipf.write(filepath, os.path.relpath(filepath, search_path))
+        bytestream.seek(0)
 
         self._log_artifact("custom_modules", bytestream, _CommonService.ArtifactTypeEnum.BLOB, 'zip')
 
@@ -2251,6 +2252,7 @@ class ExperimentRun:
                 for path in paths:
                     # TODO: save notebook
                     zipf.write(path, os.path.relpath(path, common_dir))
+            zipstream.seek(0)
 
             msg.code_version.code_archive.path = hashlib.sha256(zipstream.read()).hexdigest()
             zipstream.seek(0)

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2230,8 +2230,7 @@ class ExperimentRun:
 
             if use_git:
                 try:
-                    # TODO: if `commit_hash` is not the current one, it's dirty
-                    is_dirty = _utils.get_git_commit_dirtiness()
+                    is_dirty = _utils.get_git_commit_dirtiness(commit_hash)
                 except OSError as e:
                     print("{}; skipping".format(e))
                 else:

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2160,7 +2160,8 @@ class ExperimentRun:
         Logs the code version to this Experiment Run.
 
         A code version is either information about a Git snapshot or a bundle of Python source code
-        files.
+        files. If `find_git` is ``True``—or `remote_url` or `commit_hash` are assigned values—then
+        this function will log a Git snapshot. Otherwise, it will log Python source code files.
 
         Parameters
         ----------
@@ -2212,6 +2213,7 @@ class ExperimentRun:
                 paths = [os.path.relpath(path, repo_root)
                          for path in paths]
                 # append trailing separator to directories
+                #     This is necessary for the `os.path.commonprefix()` part later to work properly.
                 paths = [os.path.join(path, "") if os.path.isdir(path) else path
                          for path in paths]
             msg.code_version.git_snapshot.filepaths.extend(paths)
@@ -2240,9 +2242,12 @@ class ExperimentRun:
 
             # obtain deepest common directory
             #     ZipFile.write() completely drops "../" path components,
-            #     so we need to resolve them by finding a common subpath to start at
+            #     so we need to resolve them by finding a common subpath to start at.
             curr_dir = os.path.join(os.path.abspath(os.curdir), "")
             paths_plus = list(map(os.path.abspath, paths)) + [curr_dir]
+            #     `commonprefix()` works character by character; if the first few characters of two
+            #     different files are the same, `commonprefix()` will keep it. Therefore we have to
+            #     get the actual `dirname()` of the common prefix.
             common_prefix = os.path.commonprefix(paths_plus)
             common_dir = os.path.dirname(common_prefix)
 


### PR DESCRIPTION
## Changelog
- implement `ExperimentRun.log_code()` and `ExperimentRun.get_code()`

## Notes
**This does not currently auto-save the notebook.**
Instead it reads from whatever is on disk (basically the latest checkpoint).
The combination of:
- `zipfile` not allowing writes directly from stream objects
- notebook discovery, saving, and reading introducing some wack race conditions

makes it quite a headache to accommodate notebook auto-saving. I'm thinking about doing it with temp files, but that'll take a while to implement and this feature works reasonably without it.

## Examples
<img width="761" alt="Screen Shot 2019-07-06 at 2 24 11 PM" src="https://user-images.githubusercontent.com/7754936/60761298-5e0c1000-9ffa-11e9-85c2-35daeac721a8.png">
<img width="704" alt="Screen Shot 2019-07-06 at 2 24 21 PM" src="https://user-images.githubusercontent.com/7754936/60761299-5fd5d380-9ffa-11e9-8d46-73d8a2e719b9.png">