### PR TITLE
Resolve Daylight Savings Time Timestamp Fiasco

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,12 +1,13 @@
 import six
 
-from datetime import datetime
+import datetime
 import json
 import numbers
 import os
 import string
 import subprocess
 import sys
+import time
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -501,7 +502,7 @@ def timestamp_to_str(timestamp):
 
     """
     num_digits = len(str(timestamp))
-    return str(datetime.fromtimestamp(timestamp*10**(10 - num_digits)))
+    return str(datetime.datetime.fromtimestamp(timestamp*10**(10 - num_digits)))
 
 
 def now():

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -471,12 +471,8 @@ def ensure_timestamp(timestamp):
         try:  # attempt with pandas, which can parse many time string formats
             return timestamp_to_ms(pd.Timestamp(timestamp).timestamp())
         except NameError:  # pandas not installed
-            try:  # fall back on std lib, and parse as ISO 8601
-                timestamp_to_ms(to_timestamp(datetime.fromisoformat(timestamp)))
-            except ValueError:
-                six.raise_from(ValueError("`timestamp` must be in ISO 8601 format,"
-                                          " e.g. \"2017-10-30T00:44:16+00:00\""),
-                               None)
+            six.raise_from(ValueError("pandas must be installed to parse datetime strings"),
+                           None)
         except ValueError:  # can't be handled by pandas
             six.raise_from(ValueError("unable to parse datetime string \"{}\"".format(timestamp)),
                            None)

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -405,27 +405,7 @@ def generate_default_name():
         String generated from the current process ID and Unix timestamp.
 
     """
-    return "{}{}".format(os.getpid(), str(to_timestamp(datetime.now())).replace('.', ''))
-
-
-def to_timestamp(dt):
-    """
-    Converts a datetime instance into a Unix timestamp.
-
-    Equivalent to Python 3's ``dt.timestamp()`` on a naive datetime instance.
-
-    Parameters
-    ----------
-    dt : datetime.datetime
-        datetime instance.
-
-    Returns
-    -------
-    float
-        Unix timestamp.
-
-    """
-    return (dt - datetime.fromtimestamp(0)).total_seconds()
+    return "{}{}".format(os.getpid(), str(time.time()).replace('.', ''))
 
 
 def timestamp_to_ms(timestamp):
@@ -511,7 +491,7 @@ def now():
         Current Unix timestamp in milliseconds.
 
     """
-    return timestamp_to_ms(to_timestamp(datetime.now()))
+    return timestamp_to_ms(time.time())
 
 
 def get_python_version():


### PR DESCRIPTION
A wise philosopher once said:
![screen_shot_2019-07-09_at_4 46 38_pm](https://user-images.githubusercontent.com/7754936/60931647-307bcc80-a26f-11e9-986b-4629e98b1b25.png)
## Changelog
- remove `_utils.to_timestamp()` because we no longer need to convert `datetime.datetime` objects into Unix timestamps
- use `time.time()` instead of `datetime.datetime.now()`
- refuse to parse human-readable datetime strings into Unix timestamps without Pandas installed
  - Before, I would fall back to using the `datetime` module for [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) strings, but really no one uses that so it's pointless and not worth the trouble.
## Examples
The following two runs were logged at 5:32pm.
Before:
![Screen Shot 2019-07-09 at 5 35 22 PM](https://user-images.githubusercontent.com/7754936/60931824-07a80700-a270-11e9-8db5-efc26ff9cb96.png)
After:
![Screen Shot 2019-07-09 at 5 35 29 PM](https://user-images.githubusercontent.com/7754936/60931827-0ecf1500-a270-11e9-9704-617b421c64e2.png)
