### PR TITLE
Include file extension in upload path

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1851,10 +1851,12 @@ class ExperimentRun(_ModelDBEntity):
         if extension is None:
             extension = _artifact_utils.ext_from_method(method)
 
-        # obtain checksum for upload bucket
+        # calculate checksum
         artifact_hash = hashlib.sha256(artifact_stream.read()).hexdigest()
         artifact_stream.seek(0)
-        artifact_path = os.path.join(artifact_hash, basename)
+
+        # build upload path from checksum, key, and extension
+        artifact_path = os.path.join(artifact_hash, basename + os.extsep + extension)
 
         # log key to ModelDB
         Message = _ExperimentRunService.LogArtifact

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1841,9 +1841,7 @@ class ExperimentRun(_ModelDBEntity):
             Filename extension associated with the artifact.
 
         """
-        basename = key
         if isinstance(artifact, six.string_types):
-            basename = os.path.basename(artifact)
             artifact = open(artifact, 'rb')
 
         artifact_stream, method = _artifact_utils.ensure_bytestream(artifact)
@@ -1856,7 +1854,7 @@ class ExperimentRun(_ModelDBEntity):
         artifact_stream.seek(0)
 
         # build upload path from checksum, key, and extension
-        artifact_path = os.path.join(artifact_hash, basename + os.extsep + extension)
+        artifact_path = os.path.join(artifact_hash, key + os.extsep + extension)
 
         # log key to ModelDB
         Message = _ExperimentRunService.LogArtifact

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1853,8 +1853,16 @@ class ExperimentRun(_ModelDBEntity):
         artifact_hash = hashlib.sha256(artifact_stream.read()).hexdigest()
         artifact_stream.seek(0)
 
-        # build upload path from checksum, key, and extension
-        artifact_path = os.path.join(artifact_hash, key + os.extsep + extension)
+        # determine basename
+        #     The key might already contain the file extension, thanks to our hard-coded deployment
+        #     keys e.g. "model.pkl" and "model_api.json".
+        if key.endswith(os.extsep + extension):
+            basename = key
+        else:
+            basename = key + os.extsep + extension
+
+        # build upload path from checksum and basename
+        artifact_path = os.path.join(artifact_hash, basename)
 
         # log key to ModelDB
         Message = _ExperimentRunService.LogArtifact


### PR DESCRIPTION
This directly enables proper downloading of file-like Artifacts from the Web App—still without touching Artifact keys.