### PR TITLE
Add debug flag to Client for printing more verbose info

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -81,7 +81,7 @@ class Connection:
 
 
 class Configuration:
-    def __init__(self, use_git=True):
+    def __init__(self, use_git=True, debug=False):
         """
         Client behavior configuration utility struct.
 
@@ -92,6 +92,7 @@ class Configuration:
 
         """
         self.use_git = use_git
+        self.debug = debug
 
 
 def make_request(method, url, conn, **kwargs):

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -140,6 +140,14 @@ class Client:
         self._conn.ignore_conn_err = value
 
     @property
+    def debug(self):
+        return self._conf.debug
+
+    @debug.setter
+    def debug(self, value):
+        self._conf.debug = value
+
+    @property
     def expt_runs(self):
         if self.expt is None:
             return None

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -48,6 +48,8 @@ class Client:
         Whether to ignore connection errors and instead return successes with empty contents.
     use_git : bool, default True
         Whether to use a local Git repository for certain operations such as Code Versioning.
+    debug : bool, default False
+        Whether to print extra verbose information to aid in debugging.
 
     Attributes
     ----------
@@ -68,7 +70,7 @@ class Client:
     _GRPC_PREFIX = "Grpc-Metadata-"
 
     def __init__(self, host, port=None, email=None, dev_key=None,
-                 max_retries=5, ignore_conn_err=False, use_git=True):
+                 max_retries=5, ignore_conn_err=False, use_git=True, debug=False):
         if email is None and 'VERTA_EMAIL' in os.environ:
             email = os.environ['VERTA_EMAIL']
             print("set email from environment")
@@ -110,7 +112,7 @@ class Client:
         print("connection successfully established")
 
         self._conn = conn
-        self._conf = _utils.Configuration(use_git)
+        self._conf = _utils.Configuration(use_git, debug)
 
         self.proj = None
         self.expt = None


### PR DESCRIPTION
## Notes
Things to always be printed:
- when an artifact upload is complete

Things to be printed when `debug=True`:
- whether email & dev key were found on `Client.__init__()`
- what email & dev key (first 8 characters) were found
- how many bytes are being uploaded for every logged artifact
- in `log_model_for_deployment()`:
  - type of `model`
  - contents of `model_api`
  - contents of `requirements`
- in `log_modules()`:
  - contents of `sys.path`
  - contents of `search_paths`
  - contents of `custom_modules.zip`
## Examples
![Screen Shot 2019-07-26 at 1 38 49 PM](https://user-images.githubusercontent.com/7754936/61980206-e30b9900-afaa-11e9-8ed5-18b04488a1a6.png)
![Screen Shot 2019-07-26 at 1 39 02 PM](https://user-images.githubusercontent.com/7754936/61980214-e6068980-afaa-11e9-97c6-1862ce1328d8.png)
![Screen Shot 2019-07-26 at 1 39 12 PM](https://user-images.githubusercontent.com/7754936/61980215-e7d04d00-afaa-11e9-8b29-abb3455d5175.png)
![Screen Shot 2019-07-26 at 1 39 21 PM](https://user-images.githubusercontent.com/7754936/61980218-e9017a00-afaa-11e9-8272-9ac24470781b.png)
![Screen Shot 2019-07-26 at 1 39 37 PM](https://user-images.githubusercontent.com/7754936/61980221-eacb3d80-afaa-11e9-955e-5367de6df90d.png)
![Screen Shot 2019-07-26 at 1 39 43 PM](https://user-images.githubusercontent.com/7754936/61980222-ec950100-afaa-11e9-8d3a-9f4042cf7596.png)
