### PR TITLE
[WIP] #150 Add user-friendly error for authentication failure

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -136,6 +136,13 @@ class Client(object):
         except requests.ConnectionError:
             six.raise_from(requests.ConnectionError("connection failed; please check `host` and `port`"),
                            None)
+
+        def is_unauthorized(response): return response.status_code == 401
+             
+        if is_unauthorized(response):
+            auth_error_msg = "authentication failed; please check `VERTA_EMAIL` and `VERTA_DEV_KEY`"
+            six.raise_from(requests.HTTPError(auth_error_msg), None)
+
         response.raise_for_status()
         print("connection successfully established")
 


### PR DESCRIPTION
Here is my guess how to handle such case:

- `/v1/project/verifyConnection` could return _401 Unauthorized_ if headers (`Grpc-Metadata-email` and `Grpc-Metadata-developer_key`) contain invalid values. I suppose this endpoint should be modified for this case

- check the status code and raise a proper exception

I think the main point here is to prevent instantiation of `Client` with invalid credentials.

Please, suggest how should I implement this.
