### PR TITLE
Upgrade demo util predict

### DIFF
--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -1,7 +1,6 @@
 import six
 from six.moves.urllib.parse import urlparse
 
-import json
 import os
 
 import requests
@@ -88,10 +87,7 @@ class DeployedModel:
             self._set_input_headers()
 
         result = requests.post(self._prediction_url,
-                               headers={
-                                   'Access-token': self._prediction_token,
-                                   'Content-length': str(len(json.dumps(x).encode('utf-8'))),
-                               },
+                               headers={'Access-token': self._prediction_token},
                                json=x)
 
         if return_input_body:

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -43,11 +43,13 @@ class DeployedModel:
         self._token = None
         self._url = None
 
+        self._session = requests.Session()
+
     def __repr__(self):
         return "<Model {}>".format(self._id)
 
     def _set_token_and_url(self):
-        response = requests.get(self._status_url)
+        response = self._session.get(self._status_url)
         response.raise_for_status()
         status = response.json()
         if 'token' in status and 'api' in status:
@@ -61,9 +63,9 @@ class DeployedModel:
         if self._token is None or self._url is None:
             self._set_token_and_url()
 
-        result = requests.post(self._url,
-                               headers={'Access-token': self._token},
-                               json=x)
+        result = self._session.post(self._url,
+                                    headers={'Access-token': self._token},
+                                    json=x)
 
         if return_input_body:
             return result, input_body
@@ -72,7 +74,7 @@ class DeployedModel:
 
     @property
     def is_deployed(self):
-        response = requests.get(self._status_url)
+        response = self._session.get(self._status_url)
         return response.ok and 'token' in response.json()
 
     def predict(self, x):

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -56,7 +56,7 @@ class DeployedModel:
             self._session.headers['Access-token'] = status['token']
             self._url = "https://{}{}".format(self._socket, status['api'])
         else:
-            raise RuntimeError("deployment is not ready")
+            raise RuntimeError("token not found in status endpoint response")
 
     def _predict(self, x):
         """This is like ``DeployedModel.predict()``, but returns the raw ``Response`` for debugging."""

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -56,7 +56,7 @@ class DeployedModel:
             self._session.headers['Access-token'] = status['token']
             self._url = "https://{}{}".format(self._socket, status['api'])
         else:
-            raise RuntimeError("token not found in status endpoint response")
+            raise RuntimeError("token not found in status endpoint response; deployment may not be ready")
 
     def _predict(self, x):
         """This is like ``DeployedModel.predict()``, but returns the raw ``Response`` for debugging."""

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -45,7 +45,6 @@ class DeployedModel:
 
         self._token = None
         self._url = None
-        self._headers = None
 
     def __repr__(self):
         return "<Model {}>".format(self._id)
@@ -60,32 +59,10 @@ class DeployedModel:
         else:
             raise RuntimeError("deployment is not ready")
 
-    def _set_headers(self, key="model_api.json"):
-        # get url to get model_api.json from artifact store
-        params = {'id': self._id, 'key': key, 'method': "GET"}
-        response = requests.post("https://{}/v1/experiment-run/getUrlForArtifact".format(self._socket),
-                                 json=params, headers=self._auth)
-        response.raise_for_status()
-
-        # get model_api.json
-        get_artifact_url = response.json()['url']
-        response = requests.get(get_artifact_url)
-        response.raise_for_status()
-        model_api = json.loads(response.content)
-
-        model_api_input = model_api['input']
-
-        if 'fields' not in model_api_input:
-            self._headers = model_api_input['name']
-        else:
-            self._headers = [field['name'] for field in model_api_input['fields']]
-
     def _predict(self, x, return_input_body=False):
         """This is like ``DeployedModel.predict()``, but returns the raw ``Response`` for debugging."""
         if self._token is None or self._url is None:
             self._set_token_and_url()
-        if self._headers is None:
-            self._set_headers()
 
         result = requests.post(self._url,
                                headers={'Access-token': self._token},
@@ -126,8 +103,5 @@ class DeployedModel:
             self._set_token_and_url()  # try refetching prediction token and URL
             response = self._predict(x)
             if not response.ok:
-                self._set_headers()  # try refetching input headers
-                response = self._predict(x)
-                if not response.ok:
-                    return "model is warming up; please wait"
+                return "model is warming up; please wait"
         return response.json()

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -36,9 +36,6 @@ class DeployedModel:
         socket = socket.path if socket.netloc == '' else socket.netloc
 
         self._socket = socket
-        self._auth = {self._GRPC_PREFIX+'email': os.environ['VERTA_EMAIL'],
-                      self._GRPC_PREFIX+'developer_key': os.environ['VERTA_DEV_KEY'],
-                      self._GRPC_PREFIX+'source': "PythonClient"}
         self._id = model_id
 
         self._status_url = "https://{}/api/v1/deployment/status/{}".format(socket, model_id)

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -102,4 +102,5 @@ class DeployedModel:
                 print("received status {}; retrying in {:.1f}s".format(response.status_code, sleep))
                 time.sleep(sleep)
             else:
-                response.raise_for_status()
+                break
+        response.raise_for_status()

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -41,29 +41,30 @@ class DeployedModel:
                       self._GRPC_PREFIX+'source': "PythonClient"}
         self._id = model_id
 
-        self._token = None
-        self._headers = None
-
         self._status_url = "https://{}/api/v1/deployment/status/{}".format(socket, model_id)
-        self._get_url_url = "https://{}/v1/experiment-run/getUrlForArtifact".format(socket) # url to obtain artifact GET url
-        self._prediction_url = "https://{}/api/v1/predict/{}".format(socket, model_id)
+
+        self._token = None
+        self._url = None
+        self._headers = None
 
     def __repr__(self):
         return "<Model {}>".format(self._id)
 
-    def _set_token(self):
+    def _set_token_and_url(self):
         response = requests.get(self._status_url)
         response.raise_for_status()
         status = response.json()
-        try:
+        if 'token' in status and 'api' in status:
             self._token = status['token']
-        except KeyError:
-            six.raise_from(RuntimeError("deployment is not ready"), None)
+            self._url = "https://{}{}".format(self._socket, status['api'])
+        else:
+            raise RuntimeError("deployment is not ready")
 
     def _set_headers(self, key="model_api.json"):
         # get url to get model_api.json from artifact store
         params = {'id': self._id, 'key': key, 'method': "GET"}
-        response = requests.post(self._get_url_url, json=params, headers=self._auth)
+        response = requests.post("https://{}/v1/experiment-run/getUrlForArtifact".format(self._socket),
+                                 json=params, headers=self._auth)
         response.raise_for_status()
 
         # get model_api.json
@@ -81,12 +82,12 @@ class DeployedModel:
 
     def _predict(self, x, return_input_body=False):
         """This is like ``DeployedModel.predict()``, but returns the raw ``Response`` for debugging."""
-        if self._token is None:
-            self._set_token()
+        if self._token is None or self._url is None:
+            self._set_token_and_url()
         if self._headers is None:
             self._set_headers()
 
-        result = requests.post(self._prediction_url,
+        result = requests.post(self._url,
                                headers={'Access-token': self._token},
                                json=x)
 
@@ -122,10 +123,10 @@ class DeployedModel:
         response = self._predict(x)
 
         if not response.ok:
-            self._token = None  # try refetching token
+            self._set_token_and_url()  # try refetching prediction token and URL
             response = self._predict(x)
             if not response.ok:
-                self._headers = None  # try refetching input headers
+                self._set_headers()  # try refetching input headers
                 response = self._predict(x)
                 if not response.ok:
                     return "model is warming up; please wait"

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -57,17 +57,14 @@ class DeployedModel:
         else:
             raise RuntimeError("deployment is not ready")
 
-    def _predict(self, x, return_input_body=False):
+    def _predict(self, x):
         """This is like ``DeployedModel.predict()``, but returns the raw ``Response`` for debugging."""
         if 'Access-token' not in self._session.headers or self._url is None:
             self._set_token_and_url()
 
         result = self._session.post(self._url, json=x)
 
-        if return_input_body:
-            return result, input_body
-        else:
-            return result
+        return result
 
     @property
     def is_deployed(self):
@@ -94,6 +91,8 @@ class DeployedModel:
 
         """
         response = self._predict(x)
+
+
 
         if not response.ok:
             self._set_token_and_url()  # try refetching prediction token and URL

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -40,7 +40,6 @@ class DeployedModel:
 
         self._status_url = "https://{}/api/v1/deployment/status/{}".format(socket, model_id)
 
-        self._token = None
         self._url = None
 
         self._session = requests.Session()
@@ -53,19 +52,17 @@ class DeployedModel:
         response.raise_for_status()
         status = response.json()
         if 'token' in status and 'api' in status:
-            self._token = status['token']
+            self._session.headers['Access-token'] = status['token']
             self._url = "https://{}{}".format(self._socket, status['api'])
         else:
             raise RuntimeError("deployment is not ready")
 
     def _predict(self, x, return_input_body=False):
         """This is like ``DeployedModel.predict()``, but returns the raw ``Response`` for debugging."""
-        if self._token is None or self._url is None:
+        if 'Access-token' not in self._session.headers or self._url is None:
             self._set_token_and_url()
 
-        result = self._session.post(self._url,
-                                    headers={'Access-token': self._token},
-                                    json=x)
+        result = self._session.post(self._url, json=x)
 
         if return_input_body:
             return result, input_body

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -41,8 +41,8 @@ class DeployedModel:
                       self._GRPC_PREFIX+'source': "PythonClient"}
         self._id = model_id
 
-        self._prediction_token = None
-        self._input_headers = None
+        self._token = None
+        self._headers = None
 
         self._status_url = "https://{}/api/v1/deployment/status/{}".format(socket, model_id)
         self._get_url_url = "https://{}/v1/experiment-run/getUrlForArtifact".format(socket) # url to obtain artifact GET url
@@ -51,16 +51,16 @@ class DeployedModel:
     def __repr__(self):
         return "<Model {}>".format(self._id)
 
-    def _set_prediction_token(self):
+    def _set_token(self):
         response = requests.get(self._status_url)
         response.raise_for_status()
         status = response.json()
         try:
-            self._prediction_token = status['token']
+            self._token = status['token']
         except KeyError:
             six.raise_from(RuntimeError("deployment is not ready"), None)
 
-    def _set_input_headers(self, key="model_api.json"):
+    def _set_headers(self, key="model_api.json"):
         # get url to get model_api.json from artifact store
         params = {'id': self._id, 'key': key, 'method': "GET"}
         response = requests.post(self._get_url_url, json=params, headers=self._auth)
@@ -75,19 +75,19 @@ class DeployedModel:
         model_api_input = model_api['input']
 
         if 'fields' not in model_api_input:
-            self._input_headers = model_api_input['name']
+            self._headers = model_api_input['name']
         else:
-            self._input_headers = [field['name'] for field in model_api_input['fields']]
+            self._headers = [field['name'] for field in model_api_input['fields']]
 
     def _predict(self, x, return_input_body=False):
         """This is like ``DeployedModel.predict()``, but returns the raw ``Response`` for debugging."""
-        if self._prediction_token is None:
-            self._set_prediction_token()
-        if self._input_headers is None:
-            self._set_input_headers()
+        if self._token is None:
+            self._set_token()
+        if self._headers is None:
+            self._set_headers()
 
         result = requests.post(self._prediction_url,
-                               headers={'Access-token': self._prediction_token},
+                               headers={'Access-token': self._token},
                                json=x)
 
         if return_input_body:
@@ -122,10 +122,10 @@ class DeployedModel:
         response = self._predict(x)
 
         if not response.ok:
-            self._prediction_token = None  # try refetching token
+            self._token = None  # try refetching token
             response = self._predict(x)
             if not response.ok:
-                self._input_headers = None  # try refetching input headers
+                self._headers = None  # try refetching input headers
                 response = self._predict(x)
                 if not response.ok:
                     return "model is warming up; please wait"


### PR DESCRIPTION
Includes changes to `development` from #145 (get rid of input headers, enable custom prediction URLs) because my commit history is a mess.

Successful predictions have been successfully predicted with:
- [modeldb-client/workflows/examples/sklearn.ipynb](https://github.com/VertaAI/modeldb-client/blob/master/workflows/examples/sklearn.ipynb)
- [modeldb-client/workflows/examples/tensorflow.ipynb](https://github.com/VertaAI/modeldb-client/blob/master/workflows/examples/tensorflow.ipynb)
- [modeldb-client/workflows/examples/pytorch.ipynb](https://github.com/VertaAI/modeldb-client/blob/master/workflows/examples/pytorch.ipynb)
- [modeldb-client/workflows/examples/xgboost.ipynb](https://github.com/VertaAI/modeldb-client/blob/master/workflows/examples/xgboost.ipynb)

Retry logic has been tested by clear the token before predictions and ad-hoc retrying on the resulting `403`s.

For reference: [`requests.Session` documentation](https://2.python-requests.org/en/master/api/#request-sessions)