### PR TITLE
Raise exception with the backend message in case of a bad gateway

### DIFF
--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -112,6 +112,11 @@ class DeployedModel:
             response = self._predict(x, compress)
             if response.ok:
                 return response.json()
+            elif response.status_code == 502: # bad gateway; the error happened in the model backend
+                data = response.json()
+                if 'message' not in data:
+                    raise ValueError("couldn't find error message in return json")
+                raise ValueError("Got error message from backend:\n" + data['message'])
             elif response.status_code >= 500 or response.status_code == 429:
                 sleep = 0.3*(2**i_retry)  # 5 retries is 9.3 seconds total
                 print("received status {}; retrying in {:.1f}s".format(response.status_code, sleep))

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -115,8 +115,8 @@ class DeployedModel:
             elif response.status_code == 502: # bad gateway; the error happened in the model backend
                 data = response.json()
                 if 'message' not in data:
-                    raise ValueError("couldn't find error message in return json")
-                raise ValueError("Got error message from backend:\n" + data['message'])
+                    raise RuntimeError("server error (no specific error message found)")
+                raise RuntimeError("got error message from backend:\n" + data['message'])
             elif response.status_code >= 500 or response.status_code == 429:
                 sleep = 0.3*(2**i_retry)  # 5 retries is 9.3 seconds total
                 print("received status {}; retrying in {:.1f}s".format(response.status_code, sleep))


### PR DESCRIPTION
Bad gateway means that an error happened on the backend. This PR
propagates the error message back to the client. For instance:
```
ValueError: Got error message from backend:
Traceback (most recent call last):
  File "<ipython-input-81-f864aeb8f6bd>", line 6, in predict
ValueError: Foobar
```