### PR TITLE
Revert "Add support for multiple arguments in model"

### DIFF
--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -19,32 +19,6 @@ try:
 except ImportError:  # TensorFlow not installed
     pass
 
-from inspect import getargspec, ismethod
-
-def _get_model_expand_argument(func):
-    """
-    Determine if the model will require expansion of the arguments.
-
-    If a function has more than one argument, we need to transform its arguments into
-    a single value that can be passed through the wire and deserialized again. We could
-    enforce to always to do that, but we don't currently to keep backwards compatibility.
-
-    Parameters
-    ----------
-    func : callable
-        Function or method that will be used to call the model.
-
-    Returns
-    -------
-    bool
-        Flag indicating argument expansion will be required.
-
-    """
-    args = getargspec(func)
-    if ismethod(func):
-        # First argument is always "self", so we don't count it
-        return len(args.args) > 2 or args.varargs is not None or args.keywords is not None
-    return len(args.args) > 1 or args.varargs is not None or args.keywords is not None
 
 def get_file_ext(file):
     """
@@ -228,8 +202,6 @@ def serialize_model(model):
         finally:
             reset_stream(model)  # reset cursor to beginning as a courtesy
 
-    expand_arguments = False
-
     for class_obj in model.__class__.__mro__:
         module_name = class_obj.__module__
         if not module_name:
@@ -257,14 +229,12 @@ def serialize_model(model):
         if hasattr(model, 'predict'):
             model_type = "custom"
             bytestream, method = ensure_bytestream(model)
-            expand_arguments = _get_model_expand_argument(model.predict)
         elif callable(model):
             model_type = "callable"
             bytestream, method = ensure_bytestream(model)
-            expand_arguments = _get_model_expand_argument(model)
         else:
             raise TypeError("cannot determine the type for model argument")
-    return bytestream, method, model_type, expand_arguments
+    return bytestream, method, model_type
 
 
 def deserialize_model(bytestring):

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -25,10 +25,6 @@ class DeployedModel:
         Hostname of the node running the Verta backend.
     model_id : str
         id of the deployed ExperimentRun/ModelRecord.
-    compress : bool, default False
-        Whether to compress the request body.
-    max_retries : int, default 5
-        Maximum number of times to retry a request on a connection failure.
 
     Attributes
     ----------
@@ -38,14 +34,12 @@ class DeployedModel:
     """
     _GRPC_PREFIX = "Grpc-Metadata-"
 
-    def __init__(self, socket, model_id, compress=False, max_retries=5):
+    def __init__(self, socket, model_id):
         socket = urlparse(socket)
         socket = socket.path if socket.netloc == '' else socket.netloc
 
         self._socket = socket
         self._id = model_id
-        self._compress = compress
-        self._max_retries = max_retries
 
         self._status_url = "https://{}/api/v1/deployment/status/{}".format(socket, model_id)
 
@@ -91,7 +85,7 @@ class DeployedModel:
         response = self._session.get(self._status_url)
         return response.ok and 'token' in response.json()
 
-    def predict(self, *args, **kwargs):
+    def predict(self, x, compress=False, max_retries=5):
         """
         Make a prediction using input `x`.
 
@@ -102,6 +96,10 @@ class DeployedModel:
         ----------
         x : list
             List of Sequence of feature values representing a single data point.
+        compress : bool, default False
+            Whether to compress the request body.
+        max_retries : int, default 5
+            Maximum number of times to retry a request on a connection failure.
 
         Returns
         -------
@@ -110,15 +108,8 @@ class DeployedModel:
             error, None is returned instead as a silent failure.
 
         """
-        # If a single argument, assume we don't have to pack them
-        # TODO: fetch this info from the model api
-        if len(args) == 1 and len(kwargs) == 0:
-            x = args[0]
-        else:
-            x = {"args": args, "kwargs": kwargs}
-
-        for i_retry in range(self._max_retries):
-            response = self._predict(x, self._compress)
+        for i_retry in range(max_retries):
+            response = self._predict(x, compress)
             if response.ok:
                 return response.json()
             elif response.status_code == 502: # bad gateway; the error happened in the model backend

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2611,7 +2611,7 @@ class ExperimentRun(_ModelDBEntity):
             model_extension = _artifact_utils.get_file_ext(model)
         except (TypeError, ValueError):
             model_extension = None
-        model, method, model_type, expand_arguments = _artifact_utils.serialize_model(model)
+        model, method, model_type = _artifact_utils.serialize_model(model)
         if method is None:
             raise ValueError("will not be able to deploy model due to unknown serialization method")
         if model_extension is None:
@@ -2626,7 +2626,6 @@ class ExperimentRun(_ModelDBEntity):
                 'python_version': _utils.get_python_version(),
                 'type': model_type,
                 'deserialization': method,
-                'expand_arguments': expand_arguments,
             }
         if self._conf.debug:
             print("[DEBUG] model API is:")
@@ -2696,7 +2695,7 @@ class ExperimentRun(_ModelDBEntity):
         except (TypeError, ValueError):
             extension = None
 
-        model, method, _, _ = _artifact_utils.serialize_model(model)
+        model, method, _ = _artifact_utils.serialize_model(model)
 
         if extension is None:
             extension = _artifact_utils.ext_from_method(method)


### PR DESCRIPTION
Reverts VertaAI/modeldb-client#158

This will be restored once we figure out the design. The backend is backwards compatible, so it shouldn't have to change.