### PR TITLE
VR-1844: Ignore virtual environment dirs in log_modules()

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -175,14 +175,14 @@ def find_filepaths(paths, extensions=None, include_hidden=False):
     filepaths = set()
     for path in paths:
         if os.path.isdir(path):
-            for root, _, subpaths in os.walk(path):
-                if is_hidden(root) and not include_hidden:
+            for parent_dir, dirnames, filenames in os.walk(path):
+                if is_hidden(parent_dir) and not include_hidden:
                     continue  # skip hidden directories
-                for subpath in subpaths:
-                    if is_hidden(subpath) and not include_hidden:
+                for filename in filenames:
+                    if is_hidden(filename) and not include_hidden:
                         continue  # skip hidden files
-                    if extensions is None or os.path.splitext(subpath)[1] in extensions:
-                        filepaths.add(os.path.join(root, subpath))
+                    if extensions is None or os.path.splitext(filename)[1] in extensions:
+                        filepaths.add(os.path.join(parent_dir, filename))
         else:
             filepaths.add(path)
     return filepaths

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -3035,7 +3035,7 @@ class ExperimentRun(_ModelDBEntity):
         common_prefix = os.path.commonprefix(paths_plus)
         common_dir = os.path.dirname(common_prefix)
 
-        filepaths = _utils.find_filepaths(paths, include_hidden=True)
+        filepaths = _utils.find_filepaths(paths, include_hidden=True, include_venv=False)
 
         # get search paths to modify Deployment's sys.path
         if self._conf.debug:


### PR DESCRIPTION
## Changelog
- `_utils.find_filepaths()` now has a flag `include_venv: bool`

## Notes
Since a virtual environment directory could be called anything, this technique identifies such directories by looking for a `bin/python` inside.

## Examples
### Before
`run.log_modules()` is taking too long with the virtual environment, so I don't have a screenshot.
### After
This number is completely meaningless without the **Before** image.
![Screen Shot 2019-08-07 at 2 06 26 PM](https://user-images.githubusercontent.com/7754936/62658088-c3666000-b91c-11e9-9aef-445cb021a638.png)
