### PR TITLE
VR-1901: Allow custom URL and token in _demo_utils::DeployedModel

### DIFF
--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -25,8 +25,10 @@ class DeployedModel:
     ----------
     socket : str
         Hostname of the node running the Verta backend.
-    model_id : str
+    model_id : str, optional
         id of the deployed ExperimentRun/ModelRecord.
+    url : str, optional
+    token : str, optional
 
     Attributes
     ----------
@@ -36,7 +38,12 @@ class DeployedModel:
     """
     _GRPC_PREFIX = "Grpc-Metadata-"
 
-    def __init__(self, socket, model_id):
+    def __init__(self, socket, model_id=None, url=None, token=None):
+        if model_id is None and (url is None or token is None):
+            raise ValueError("`url` and `token` must be provided together")
+        elif model_id is not None and (url is not None or token is not None):
+            raise ValueError("`url` and `token` cannot be provided if `model_id` is provided")
+
         socket = urlparse(socket)
         socket = socket.path if socket.netloc == '' else socket.netloc
 

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -24,11 +24,13 @@ class DeployedModel:
     Parameters
     ----------
     socket : str
-        Hostname of the node running the Verta backend.
+        Hostname of the node running the Verta backend, e.g. "app.verta.ai".
     model_id : str, optional
-        id of the deployed ExperimentRun/ModelRecord.
+        ID of the deployed ExperimentRun/ModelRecord.
     url : str, optional
+        Prediction endpoint URL or path. Can be copy and pasted directly from the Verta Web App.
     token : str, optional
+        Prediction token. Can be copy and pasted directly from the Verta Web App.
 
     Attributes
     ----------

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -41,6 +41,9 @@ class DeployedModel:
         socket = socket.path if socket.netloc == '' else socket.netloc
 
         self._socket = socket
+        self._auth = {self._GRPC_PREFIX+'email': os.environ['VERTA_EMAIL'],
+                      self._GRPC_PREFIX+'developer_key': os.environ.get('VERTA_DEV_KEY'),
+                      self._GRPC_PREFIX+'source': "PythonClient"}
         self._id = model_id
 
         self._status_url = "https://{}/api/v1/deployment/status/{}".format(socket, model_id)


### PR DESCRIPTION
## Examples
Existing behavior:
![Screen Shot 2019-08-08 at 9 57 38 AM](https://user-images.githubusercontent.com/7754936/62722694-ded87600-b9c3-11e9-8baa-36d078a19a1c.png)
New parameters, values copy and pasted directly from Web App:
![Screen Shot 2019-08-08 at 9 58 00 AM](https://user-images.githubusercontent.com/7754936/62722695-ded87600-b9c3-11e9-8709-949ea353a418.png)
In case some wild user provides the full URL for `url`:
![Screen Shot 2019-08-08 at 9 58 21 AM](https://user-images.githubusercontent.com/7754936/62722696-ded87600-b9c3-11e9-8a30-daf540985ad1.png)
In case user provides `run_id` along with new parameters:
![Screen Shot 2019-08-08 at 10 00 15 AM](https://user-images.githubusercontent.com/7754936/62722697-ded87600-b9c3-11e9-9c56-74da4f5ba6e9.png)
In case user fails to provide both `url` and `token`:
![Screen Shot 2019-08-08 at 10 00 28 AM](https://user-images.githubusercontent.com/7754936/62722698-df710c80-b9c3-11e9-8b49-042f4935d33f.png)
