### PR TITLE
Added handling of deployed models with errors

### DIFF
--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -81,7 +81,7 @@ class DeployedModel:
         response.raise_for_status()
         status = response.json()
         if status['status'] == 'error':
-            raise RuntimeError("Error in deployed model: %s" % status['message'])
+            raise RuntimeError(status['message'])
         if 'token' in status and 'api' in status:
             self._session.headers['Access-Token'] = status['token']
             self._prediction_url = urljoin("https://{}".format(self._socket), status['api'])

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -80,6 +80,8 @@ class DeployedModel:
         response = self._session.get(self._status_url)
         response.raise_for_status()
         status = response.json()
+        if status['status'] == 'error':
+            raise RuntimeError("Error in deployed model: %s" % status['message'])
         if 'token' in status and 'api' in status:
             self._session.headers['Access-Token'] = status['token']
             self._prediction_url = urljoin("https://{}".format(self._socket), status['api'])


### PR DESCRIPTION
The status endpoint returns a message as follows when the deployed model has an error: 
```
{
    "status": "error",
    "message": "Model killed: out of memory"
}
```
Added a RuntimeError message with the error detail. This a screenshot of the error msg: 
![image](https://user-images.githubusercontent.com/755388/62905810-f3e53a00-bd20-11e9-890c-116dc5886985.png)

Any suggestions on formatting since this is a bit cluttered?