### PR TITLE
1776: Support passing a full URI as host in Client(host)

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -123,9 +123,13 @@ class Client(object):
         back_end_url = urlparse(host)
         scheme = back_end_url.scheme or scheme
         socket = back_end_url.netloc + back_end_url.path.rstrip('/')
+        if port is not None:
+            warnings.warn("`port` (the second parameter) will removed in a later version;"
+                          " please combine it with the first parameter, e.g. \"localhost:8080\"",
+                          category=DeprecationWarning, stacklevel=2)
+            socket = "{}:{}".format(socket, port)
 
         # verify connection
-        socket = socket if port is None else "{}:{}".format(socket, port)
         conn = _utils.Connection(scheme, socket, auth, max_retries, ignore_conn_err)
         try:
             response = _utils.make_request("GET",

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -126,7 +126,7 @@ class Client(object):
         if port is not None:
             warnings.warn("`port` (the second parameter) will removed in a later version;"
                           " please combine it with the first parameter, e.g. \"localhost:8080\"",
-                          category=DeprecationWarning, stacklevel=2)
+                          category=FutureWarning)
             socket = "{}:{}".format(socket, port)
 
         # verify connection
@@ -3019,7 +3019,7 @@ class ExperimentRun(_ModelDBEntity):
         if search_path is not None:
             warnings.warn("`search_path` is no longer used and will removed in a later version;"
                           " consider removing it from the function call",
-                          category=DeprecationWarning, stacklevel=2)
+                          category=FutureWarning)
         if isinstance(paths, six.string_types):
             paths = [paths]
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -103,6 +103,7 @@ class Client(object):
             dev_key = os.environ['VERTA_DEV_KEY']
             print("set developer key from environment")
 
+        scheme = auth = None
         if email is None and dev_key is None:
             if debug:
                 print("[DEBUG] email and developer key not found; auth disabled")
@@ -119,17 +120,12 @@ class Client(object):
         else:
             raise ValueError("`email` and `dev_key` must be provided together")
 
-        host = urlparse(host)
-        if host.netloc == '':
-            # We passed a host that cannot be resolved into a basic URL. Assume it's the right path
-            host = host.path
-        else:
-            # Otherwise, just get the netlocation, which contains the hostname and port
-            # TODO(conrado): support subpaths? (e.g. example.com/backend)
-            host = host.netloc
+        back_end_url = urlparse(host)
+        scheme = back_end_url.scheme or scheme
+        socket = back_end_url.netloc + back_end_url.path.rstrip('/')
 
         # verify connection
-        socket = host if port is None else "{}:{}".format(host, port)
+        socket = socket if port is None else "{}:{}".format(socket, port)
         conn = _utils.Connection(scheme, socket, auth, max_retries, ignore_conn_err)
         try:
             response = _utils.make_request("GET",


### PR DESCRIPTION
## Changelog
- support passing a full URI as `host` in `Client(host)`
- mark `port` in `Client(host, port)` as soon-to-be-deprecated

## Notes
- Previously, `scheme` would be `"http"` if auth credentials are not provided, and `"https"` if they are. This is still the default, but if a scheme is present in `host` (e.g. `"http://dev.verta.ai/`) then it will be used instead.

## Examples
This is the logic being used. Note that  `scheme == None` represents using the default mentioned in **Notes**.
![Screen Shot 2019-08-13 at 8 05 10 AM](https://user-images.githubusercontent.com/7754936/62952833-45350e00-bda1-11e9-9146-ddc9b14538f9.png)
