### PR TITLE
VR-2010: Implement Specific Dataset Subclasses

### DIFF
--- a/verta/tests/test_datasets.py
+++ b/verta/tests/test_datasets.py
@@ -96,15 +96,13 @@ class TestPathDatasets:
 class TestClientDatasetFunctions:
     def test_creation_from_scratch_client_api(self, client):
         name = utils.gen_str()
-        dataset = client.create_dataset(name=name,
-                                        dataset_type=_DatasetService.DatasetTypeEnum.PATH)
+        dataset = client.create_dataset(name=name, type="s3")
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
     def test_creation_by_id_client_api(self, client):
         name = utils.gen_str()
-        dataset = client.create_dataset(name=name,
-                                        dataset_type=_DatasetService.DatasetTypeEnum.PATH)
+        dataset = client.create_dataset(name=name, type="s3")
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
@@ -114,8 +112,7 @@ class TestClientDatasetFunctions:
 
     def test_get_dataset_client_api(self, client):
         name = utils.gen_str()
-        dataset = client.create_dataset(name=name,
-                                        dataset_type=_DatasetService.DatasetTypeEnum.PATH)
+        dataset = client.create_dataset(name=name, type="s3")
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
@@ -130,20 +127,17 @@ class TestClientDatasetFunctions:
 
     def test_get_all_datasets_client_api(self, client):
         name = utils.gen_str()
-        dataset1 = client.create_dataset(name=name,
-                                         dataset_type=_DatasetService.DatasetTypeEnum.QUERY)
+        dataset1 = client.create_dataset(name=name, type="big query")
         assert dataset1.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
         assert dataset1.id
 
         name = utils.gen_str()
-        dataset2 = client.create_dataset(name=name,
-                                         dataset_type=_DatasetService.DatasetTypeEnum.PATH)
+        dataset2 = client.create_dataset(name=name, type="s3")
         assert dataset2.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset2.id
 
         name = utils.gen_str()
-        dataset3 = client.create_dataset(name=name,
-                                         dataset_type=_DatasetService.DatasetTypeEnum.RAW)
+        dataset3 = client.create_dataset(name=name, type="raw")
         assert dataset3.dataset_type == _DatasetService.DatasetTypeEnum.RAW
         assert dataset3.id
 
@@ -162,8 +156,7 @@ class TestClientDatasetFunctions:
 class TestClientDatasetVersionFunctions:
     def test_creation_from_scratch(self, client):
         name = utils.gen_str()
-        dataset = client.create_dataset(name=name,
-                                        dataset_type=_DatasetService.DatasetTypeEnum.PATH)
+        dataset = client.create_dataset(name=name, type="s3")
 
         version = client.create_dataset_version(dataset=dataset,
                                                 dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
@@ -173,8 +166,7 @@ class TestClientDatasetVersionFunctions:
 
     def test_creation_by_id(self, client):
         name = utils.gen_str()
-        dataset = client.create_dataset(name=name,
-                                        dataset_type=_DatasetService.DatasetTypeEnum.PATH)
+        dataset = client.create_dataset(name=name, type="s3")
 
         version = client.create_dataset_version(dataset=dataset,
                                                 dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
@@ -187,8 +179,7 @@ class TestClientDatasetVersionFunctions:
 
     def test_get_versions(self, client):
         name = utils.gen_str()
-        dataset = client.create_dataset(name=name,
-                                        dataset_type=_DatasetService.DatasetTypeEnum.PATH)
+        dataset = client.create_dataset(name=name, type="s3")
 
         version1 = client.create_dataset_version(dataset=dataset,
                                                  dataset_version_info=_DatasetVersionService.PathDatasetVersionInfo(),
@@ -331,12 +322,12 @@ class TestS3DatasetVersionInfo:
 class TestS3ClientFunctions:
     def test_s3_dataset_creation(self, client):
         name = utils.gen_str()
-        dataset = client.create_s3_dataset("s3-" + name)
+        dataset = client.create_dataset("s3-" + name, type="s3")
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
 
     def test_s3_dataset_version_creation(self, client, s3_bucket):
         name = utils.gen_str()
-        dataset = client.create_s3_dataset("s3-" + name)
+        dataset = client.create_dataset("s3-" + name, type="s3")
         dataset_version = client.create_s3_dataset_version(dataset,
             s3_bucket)
 
@@ -346,13 +337,13 @@ class TestS3ClientFunctions:
 class TestFilesystemClientFunctions:
     def test_filesystem_dataset_creation(self, client):
         name = utils.gen_str()
-        dataset = client.create_local_dataset("fs-" + name)
+        dataset = client.create_dataset("fs-" + name, type="local")
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
 
     def test_filesystem_dataset_version_creation(self, client):
         dir_name, _ = self.create_dir_with_files(num_files=3)
         name = utils.gen_str()
-        dataset = client.create_local_dataset("fs-" + name)
+        dataset = client.create_dataset("fs-" + name, type="local")
         dataset_version = client.create_local_dataset_version(dataset,
             dir_name)
 
@@ -374,12 +365,12 @@ class TestFilesystemClientFunctions:
 class TestBigQueryDatasetVersionInfo:
     def test_big_query_dataset(self, client):
         name = utils.gen_str()
-        dataset = client.create_big_query_dataset("bq-" + name)
+        dataset = client.create_dataset("bq-" + name, type="big query")
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
 
     def test_big_query_dataset_version_creation(self, client, big_query_job):
         name = utils.gen_str()
-        dataset = client.create_big_query_dataset("bq-" + name)
+        dataset = client.create_dataset("bq-" + name, type="big query")
         dataset_version = client.create_big_query_dataset_version(dataset,
             job_id=big_query_job[0], location=big_query_job[1])
 
@@ -389,7 +380,7 @@ class TestBigQueryDatasetVersionInfo:
 class TestLogDatasetVersion:
     def test_log_dataset_version(self, client, experiment_run, s3_bucket):
         name = utils.gen_str()
-        dataset = client.create_s3_dataset("s3-" + name)
+        dataset = client.create_dataset("s3-" + name, type="s3")
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
 
         dataset_version = client.create_s3_dataset_version(dataset, s3_bucket)

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -309,25 +309,25 @@ class Client(object):
                              desc, tags, attrs)
 
     # NOTE: dataset visibility cannot be set via a client
-    def create_dataset(self, name=None, dataset_type=None,
+    def create_dataset(self, name=None, type="raw",
                        desc=None, tags=None, attrs=None,
                        id=None):
-        return _dataset.Dataset(self._conn, self._conf,
-                       name=name, dataset_type=dataset_type,
-                       desc=desc, tags=tags, attrs=attrs,
+        if type == "raw":
+            DatasetSubclass = _dataset.RawDataset
+        elif type == "s3":
+            DatasetSubclass = _dataset.S3Dataset
+        elif type == "local":
+            DatasetSubclass = _dataset.LocalDataset
+        elif type == "big query":
+            DatasetSubclass = _dataset.BigQueryDataset
+        elif type == "atlas hive":
+            DatasetSubclass = _dataset.AtlasHiveDataset
+        else:
+            raise ValueError("`type` must be one of {'raw', 's3', 'local', 'big query', 'atlas hive'}")
+
+        return DatasetSubclass(self._conn, self._conf,
+                       name=name, desc=desc, tags=tags, attrs=attrs,
                        _dataset_id=id)
-
-    def create_s3_dataset(self, name):
-        return self.create_dataset(name, dataset_type=_dataset._DatasetService.DatasetTypeEnum.PATH)
-
-    def create_local_dataset(self, name):
-        return self.create_dataset(name, dataset_type=_dataset._DatasetService.DatasetTypeEnum.PATH)
-
-    def create_big_query_dataset(self, name):
-        return self.create_dataset(name, dataset_type=_dataset._DatasetService.DatasetTypeEnum.QUERY)
-
-    def create_atlas_hive_dataset(self, name):
-        return self.create_dataset(name, dataset_type=_dataset._DatasetService.DatasetTypeEnum.QUERY)
 
     # TODO: needs a by name after backend implements
     def get_dataset(self, id):


### PR DESCRIPTION
## Changelog
- unify `client.create_*_dataset()`s into a single `client.create_dataset(type="*")`
- subclass `Dataset` to handle specific Datasets

# Notes
This is being done to enable `dataset.create_version()`, since e.g. S3 and BigQuery Datasets have different `VersionInfo`s