### PR TITLE
Rename create_dataset() to set_dataset()

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -309,9 +309,12 @@ class Client(object):
                              desc, tags, attrs)
 
     # NOTE: dataset visibility cannot be set via a client
-    def create_dataset(self, name=None, type="raw",
+    def set_dataset(self, name=None, type="raw",
                        desc=None, tags=None, attrs=None,
                        id=None):
+        # Note: If a dataset with `name` already exists,
+        #       there is no way to determine its type/subclass from back end,
+        #       so it is assumed that the user has passed in the correct `type`.
         if type == "raw":
             DatasetSubclass = _dataset.RawDataset
         elif type == "s3":

--- a/workflows/demos/census-end-to-end-local-data-example.ipynb
+++ b/workflows/demos/census-end-to-end-local-data-example.ipynb
@@ -158,8 +158,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = client.create_dataset(name=\"census{}\".format(str(time.time())),\n",
-    "                                type=\"local\")\n",
+    "dataset = client.set_dataset(name=\"census{}\".format(str(time.time())),\n",
+    "                             type=\"local\")\n",
     "version = dataset.create_version(path=\"census-train.csv\")"
    ]
   },

--- a/workflows/demos/census-end-to-end-s3-example.ipynb
+++ b/workflows/demos/census-end-to-end-s3-example.ipynb
@@ -158,8 +158,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = client.create_dataset(name=\"census{}\".format(str(time.time())),\n",
-    "                                type=\"s3\")\n",
+    "dataset = client.set_dataset(name=\"census{}\".format(str(time.time())),\n",
+    "                             type=\"s3\")\n",
     "version = dataset.create_version(bucket_name=\"verta-starter\")"
    ]
   },

--- a/workflows/demos/nyc-taxi-atlas-end-to-end.ipynb
+++ b/workflows/demos/nyc-taxi-atlas-end-to-end.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = client.create_dataset(\"NYC Taxi Dataset on Atlas and Hive\", type=\"atlas hive\")"
+    "dataset = client.set_dataset(\"NYC Taxi Dataset on Atlas and Hive\", type=\"atlas hive\")"
    ]
   },
   {


### PR DESCRIPTION
This is to be consistent with the existing `set_project()`, `set_experiment()` nomenclature we're using, where `set` means "get if exists, otherwise create".

There's also a little/major bug here that's been logged as VR-2088