### PR TITLE
Various patches

### DIFF
--- a/verta/verta/_dataset.py
+++ b/verta/verta/_dataset.py
@@ -300,7 +300,10 @@ class DatasetVersion(object):
         self.dataset_version_info = None
 
     def __repr__(self):
-        return "<DatasetVersion \"{}\">".format(self.id)
+        msg_copy = _DatasetVersionService.DatasetVersion()
+        msg_copy.CopyFrom(self.dataset_version)
+        msg_copy.owner = ''  # hide owner field
+        return msg_copy.__repr__()
 
     # TODO: get by dataset_id and version is not supported on the backend
     @staticmethod

--- a/verta/verta/_demo_utils.py
+++ b/verta/verta/_demo_utils.py
@@ -130,7 +130,7 @@ class DeployedModel:
             Maximum number of times to retry a request on a connection failure.
 
         Returns
-        -------s
+        -------
         prediction : dict or None
             Output returned by the deployed model for `x`. If the prediction request returns an
             error, None is returned instead as a silent failure.

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1434,7 +1434,7 @@ class ExperimentRun(_ModelDBEntity):
         response.raise_for_status()
         print("upload complete ({})".format(basename))
 
-    def _log_artifact_path(self, key, artifact_path, artifact_type, linked_artifact_id=None):
+    def _log_artifact_path(self, key, artifact_path, artifact_type):
         """
         Logs the filesystem path of an artifact to this Experiment Run.
 
@@ -1446,17 +1446,13 @@ class ExperimentRun(_ModelDBEntity):
             Filesystem path of the artifact.
         artifact_type : int
             Variant of `_CommonService.ArtifactTypeEnum`.
-        # TODO: this design might need to be revisited by @miliu
-        linked_artifact_id: string, optional
-            Id of linked artifact
         """
         # log key-path to ModelDB
         Message = _ExperimentRunService.LogArtifact
         artifact_msg = _CommonService.Artifact(key=key,
                                                path=artifact_path,
                                                path_only=True,
-                                               artifact_type=artifact_type,
-                                               linked_artifact_id=linked_artifact_id)
+                                               artifact_type=artifact_type)
         msg = Message(id=self.id, artifact=artifact_msg)
         data = _utils.proto_to_json(msg)
         response = _utils.make_request("POST",


### PR DESCRIPTION
## Changelog
- implement a more helpful `DatasetVersion.__repr__()`
- remove a stray letter in a docstring
- remove unused `ExperimentRun._log_artifact_path(…, linked_artifact_id)`
- support getting old artifact- and path-based datasets

## Notes
Behold, the power of backwards compatibility:
![Screen Shot 2019-08-20 at 9 03 40 AM](https://user-images.githubusercontent.com/7754936/63364015-92792880-c329-11e9-9214-1f6092b8bb4a.png)