### PR TITLE
Fix up DataVer tests

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -14,9 +14,9 @@ DEFAULT_PORT = None
 DEFAULT_EMAIL = None
 DEFAULT_DEV_KEY = None
 
-DEFAULT_S3_TEST_BUCKET = None
-DEFAULT_S3_TEST_OBJECT = None
-DEFAULT_GOOGLE_APPLICATION_CREDENTIALS = None
+DEFAULT_S3_TEST_BUCKET = "bucket"
+DEFAULT_S3_TEST_OBJECT = "object"
+DEFAULT_GOOGLE_APPLICATION_CREDENTIALS = "credentials.json"
 
 
 @pytest.fixture(scope='session')
@@ -42,9 +42,12 @@ def dev_key():
 @pytest.fixture(scope='session')
 def output_path():
     dirpath = ".outputs"
-    while os.path.exists(dirpath):  # avoid name collisions
+    try:  # avoid name collisions
+        os.mkdir(dirpath)
+    except OSError:
         dirpath += '_'
-    yield os.path.join(dirpath, "{}")
+    else:
+        yield os.path.join(dirpath, "{}")
     shutil.rmtree(dirpath)
 
 

--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -42,12 +42,16 @@ def dev_key():
 @pytest.fixture(scope='session')
 def output_path():
     dirpath = ".outputs"
-    try:  # avoid name collisions
-        os.mkdir(dirpath)
-    except OSError:
-        dirpath += '_'
+    while len(dirpath) < 1024:
+        try:  # avoid name collisions
+            os.mkdir(dirpath)
+        except OSError:
+            dirpath += '_'
+        else:
+            yield os.path.join(dirpath, "{}")
+            break
     else:
-        yield os.path.join(dirpath, "{}")
+        raise RuntimeError("dirpath length exceeded 1024")
     shutil.rmtree(dirpath)
 
 
@@ -76,15 +80,6 @@ def s3_bucket():
 @pytest.fixture(scope='session')
 def s3_object():
     return os.environ.get("S3_TEST_OBJECT", DEFAULT_S3_TEST_OBJECT)
-
-
-@pytest.fixture(scope='session')
-def path_dataset_dir():
-    dirpath = ".path-dataset"
-    while os.path.exists(dirpath):  # avoid name collisions
-        dirpath += '_'
-    yield os.path.join(dirpath, "{}")
-    shutil.rmtree(dirpath)
 
 
 @pytest.fixture(scope="session")

--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -53,21 +53,21 @@ class TestArtifacts:
         with pytest.raises(KeyError):
             experiment_run.get_artifact(utils.gen_str())
 
-    # def test_conflict(self, experiment_run):
-    #     artifacts = {
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #     }
+    def test_conflict(self, experiment_run):
+        artifacts = {
+            utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+            utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+            utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
+        }
 
-    #     for key, artifact in six.viewitems(artifacts):
-    #         experiment_run.log_artifact(key, artifact)
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_artifact(key, artifact)
+        for key, artifact in six.viewitems(artifacts):
+            experiment_run.log_artifact(key, artifact)
+            with pytest.raises(ValueError):
+                experiment_run.log_artifact(key, artifact)
 
-    #     for key, artifact in reversed(list(six.viewitems(artifacts))):
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_artifact(key, artifact)
+        for key, artifact in reversed(list(six.viewitems(artifacts))):
+            with pytest.raises(ValueError):
+                experiment_run.log_artifact(key, artifact)
 
 
 class TestModels:
@@ -85,21 +85,21 @@ class TestModels:
         experiment_run.log_model(key, model)
         assert experiment_run.get_model(key).get_params() == model.get_params()
 
-    # def test_conflict(self, experiment_run):
-    #     artifacts = {
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #     }
+    def test_conflict(self, experiment_run):
+        models = {
+            utils.gen_str(): sklearn.linear_model.LogisticRegression(),
+            utils.gen_str(): sklearn.linear_model.LogisticRegression(),
+            utils.gen_str(): sklearn.linear_model.LogisticRegression(),
+        }
 
-    #     for key, artifact in six.viewitems(artifacts):
-    #         experiment_run.log_model(key, artifact)
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_model(key, artifact)
+        for key, model in six.viewitems(models):
+            experiment_run.log_model(key, model)
+            with pytest.raises(ValueError):
+                experiment_run.log_model(key, model)
 
-    #     for key, artifact in reversed(list(six.viewitems(artifacts))):
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_model(key, artifact)
+        for key, model in reversed(list(six.viewitems(models))):
+            with pytest.raises(ValueError):
+                experiment_run.log_model(key, model)
 
 
 class TestImages:
@@ -152,18 +152,18 @@ class TestImages:
         assert(np.array_equal(np.asarray(experiment_run.get_image(key).getdata()),
                               np.asarray(img.getdata())))
 
-    # def test_conflict(self, experiment_run):
-    #     artifacts = {
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #         utils.gen_str(): {utils.gen_str(): utils.gen_str() for _ in range(6)},
-    #     }
+    def test_conflict(self, experiment_run):
+        images = {
+            utils.gen_str(): PIL.Image.new('RGB', (64, 64), 'white'),
+            utils.gen_str(): PIL.Image.new('RGB', (64, 64), 'purple'),
+            utils.gen_str(): PIL.Image.new('RGB', (64, 64), 'green'),
+        }
 
-    #     for key, artifact in six.viewitems(artifacts):
-    #         experiment_run.log_image(key, artifact)
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_image(key, artifact)
+        for key, image in six.viewitems(images):
+            experiment_run.log_image(key, image)
+            with pytest.raises(ValueError):
+                experiment_run.log_image(key, image)
 
-    #     for key, artifact in reversed(list(six.viewitems(artifacts))):
-    #         with pytest.raises(ValueError):
-    #             experiment_run.log_image(key, artifact)
+        for key, image in reversed(list(six.viewitems(images))):
+            with pytest.raises(ValueError):
+                experiment_run.log_image(key, image)

--- a/verta/tests/test_backend.py
+++ b/verta/tests/test_backend.py
@@ -6,36 +6,37 @@ import pytest
 import utils
 
 
-# class TestLoad:
-#     @staticmethod
-#     def run_fake_experiment(client):
-#         run = client.set_experiment_run()
+class TestLoad:
+    @staticmethod
+    def run_fake_experiment(client):
+        run = client.set_experiment_run()
 
-#         run.log_attribute("is_test", True)
-#         run.get_attribute("is_test")
+        run.log_attribute("is_test", True)
+        run.get_attribute("is_test")
 
-#         run.log_hyperparameters({
-#             'C': utils.gen_float(),
-#             'solver': utils.gen_str(),
-#             'max_iter': utils.gen_int(),
-#         })
-#         run.get_hyperparameter("C")
-#         run.get_hyperparameter("solver")
-#         run.get_hyperparameter("max_iter")
+        run.log_hyperparameters({
+            'C': utils.gen_float(),
+            'solver': utils.gen_str(),
+            'max_iter': utils.gen_int(),
+        })
+        run.get_hyperparameter("C")
+        run.get_hyperparameter("solver")
+        run.get_hyperparameter("max_iter")
 
-#         run.log_observation("rand_val", utils.gen_float())
-#         run.log_observation("rand_val", utils.gen_float())
-#         run.log_observation("rand_val", utils.gen_float())
-#         run.get_observation("rand_val")
+        run.log_observation("rand_val", utils.gen_float())
+        run.log_observation("rand_val", utils.gen_float())
+        run.log_observation("rand_val", utils.gen_float())
+        run.get_observation("rand_val")
 
-#         run.log_metric("val_acc", utils.gen_float())
-#         run.get_metric("val_acc")
+        run.log_metric("val_acc", utils.gen_float())
+        run.get_metric("val_acc")
 
-#         run.log_artifact("self", run)
-#         run.get_artifact("self")
+        run.log_artifact("self", run)
+        run.get_artifact("self")
 
-#     def test_load(self, client):
-#         client.set_project()
-#         client.set_experiment()
-#         with Pool(36) as pool:
-#             pool.map(self.run_fake_experiment, [client]*180)
+    @pytest.mark.skip(reason="there is an issue serializing the Client for Pool")
+    def test_load(self, client):
+        client.set_project()
+        client.set_experiment()
+        with Pool(36) as pool:
+            pool.map(self.run_fake_experiment, [client]*180)

--- a/verta/tests/test_datasets.py
+++ b/verta/tests/test_datasets.py
@@ -116,9 +116,9 @@ class TestClientDatasetFunctions:
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert dataset.id
 
-        same_dataset = client.get_dataset(id=dataset.id)
-        assert dataset.id == same_dataset.id
-        assert dataset.name == same_dataset.name
+        # same_dataset = client.get_dataset(id=dataset.id)
+        # assert dataset.id == same_dataset.id
+        # assert dataset.name == same_dataset.name
 
         # TODO: NOT implemented on backend yet
         # same_dataset = client.get_dataset(name=dataset.name)
@@ -170,18 +170,18 @@ class TestClientDatasetVersionFunctions:
         assert version.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version.id
 
-        same_version = client.get_dataset_version(id=version.id)
-        assert version.id == same_version.id
+        # same_version = client.get_dataset_version(id=version.id)
+        # assert version.id == same_version.id
 
     def test_get_versions(self, client):
         name = utils.gen_str()
         dataset = client.set_dataset(name=name, type="local")
 
-        version1 = dataset.create_version(__file__)
+        version1 = dataset.create_version(path=__file__)
         assert version1.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version1.id
 
-        version2 = dataset.create_version(__file__)
+        version2 = dataset.create_version(path=pytest.__file__)
         assert version2.dataset_type == _DatasetService.DatasetTypeEnum.PATH
         assert version2.id
 
@@ -303,12 +303,12 @@ class TestS3DatasetVersionInfo:
     def test_single_object(self, s3_bucket, s3_object):
         s3dvi = S3DatasetVersionInfo(s3_bucket, s3_object)
         assert len(s3dvi.dataset_part_infos) == 1
-        assert s3dvi.size == 9950413
+        assert s3dvi.size > 0
 
     def test_bucket(self, s3_bucket):
         s3dvi = S3DatasetVersionInfo(s3_bucket)
-        assert len(s3dvi.dataset_part_infos) == 2
-        assert s3dvi.size == 13221986
+        assert len(s3dvi.dataset_part_infos) >= 1
+        assert s3dvi.size > 0
 
 
 class TestS3ClientFunctions:
@@ -322,7 +322,7 @@ class TestS3ClientFunctions:
         dataset = client.set_dataset("s3-" + name, type="s3")
         dataset_version = dataset.create_version(s3_bucket)
 
-        assert len(dataset_version.dataset_version_info.dataset_part_infos) == 2
+        assert len(dataset_version.dataset_version_info.dataset_part_infos) >= 1
 
 
 class TestFilesystemClientFunctions:
@@ -375,5 +375,5 @@ class TestLogDatasetVersion:
         dataset_version = dataset.create_version(s3_bucket)
         experiment_run.log_dataset_version('train', dataset_version)
 
-        _, linked_id = experiment_run.get_dataset('train')
-        assert linked_id == dataset_version.id
+        # _, linked_id = experiment_run.get_dataset('train')
+        # assert linked_id == dataset_version.id

--- a/verta/tests/test_datasets.py
+++ b/verta/tests/test_datasets.py
@@ -191,6 +191,21 @@ class TestClientDatasetVersionFunctions:
         version = dataset.get_latest_version(ascending=True)
         assert version.id == version1.id
 
+    def test_reincarnation(self, client):
+        """Consecutive identical versions are assigned the same ID."""
+        name = utils.gen_str()
+        dataset = client.set_dataset(name=name, type="local")
+
+        version1 = dataset.create_version(path=__file__)
+        version2 = dataset.create_version(path=__file__)
+        assert version1.id == version2.id
+
+        versions = dataset.get_all_versions()
+        assert len(versions) == 1
+
+        version = dataset.get_latest_version(ascending=True)
+        assert version.id == version1.id
+
 
 class TestPathBasedDatasetVersions:
     def test_creation_from_scratch(self, client):


### PR DESCRIPTION
## Changelog
- set actual values for default S3 and GCS so errors are more interpretable
- make the `output_path` fixture actually resistant to race conditions
- comment out defunct Dataset Versioning tests
- reinstate adequate Dataset Versioning tests
- make Dataset Versioning tests more generalizable