### PR TITLE
Support gets when val is None

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1743,10 +1743,11 @@ class ExperimentRun(_ModelDBEntity):
         response.raise_for_status()
 
         response_msg = _utils.json_to_proto(response.json(), Message.Response)
-        attribute =  _utils.unravel_key_values(response_msg.attributes).get(key)
-        if attribute is None:
-            raise KeyError("no attribute found with key {}".format(key))
-        return attribute
+        attributes = _utils.unravel_key_values(response_msg.attributes)
+        try:
+            return attributes[key]
+        except KeyError:
+            six.raise_from(KeyError("no attribute found with key {}".format(key)), None)
 
     def get_attributes(self):
         """
@@ -1855,10 +1856,11 @@ class ExperimentRun(_ModelDBEntity):
         response.raise_for_status()
 
         response_msg = _utils.json_to_proto(response.json(), Message.Response)
-        metric = _utils.unravel_key_values(response_msg.metrics).get(key)
-        if metric is None:
-            raise KeyError("no metric found with key {}".format(key))
-        return metric
+        metrics = _utils.unravel_key_values(response_msg.metrics)
+        try:
+            return metrics[key]
+        except KeyError:
+            six.raise_from(KeyError("no metric found with key {}".format(key)), None)
 
     def get_metrics(self):
         """
@@ -1965,10 +1967,11 @@ class ExperimentRun(_ModelDBEntity):
         response.raise_for_status()
 
         response_msg = _utils.json_to_proto(response.json(), Message.Response)
-        hyperparameter = _utils.unravel_key_values(response_msg.hyperparameters).get(key)
-        if hyperparameter is None:
-            raise KeyError("no hyperparameter found with key {}".format(key))
-        return hyperparameter
+        hyperparameters = _utils.unravel_key_values(response_msg.hyperparameters)
+        try:
+            return hyperparameters[key]
+        except KeyError:
+            six.raise_from(KeyError("no hyperparameter found with key {}".format(key)), None)
 
     def get_hyperparameters(self):
         """


### PR DESCRIPTION
Before, `get_metric(key)`, `get_hyperparameter(key)`, etc. would call the `getMetrics` RPC,
and then attempt a `.get(key)` on a dictionary representation of that response.
If the result of the `.get(key)` is `None`, then the Client would raise a `KeyError`.

This is problematic because if the user genuinely logs `None` as the value, `get_metric()` would result in a false negative. This PR fixes that.

This unblocks tests I have which verify that `None` can be logged as values.

## Notes
The WebApp currently displays `null` values as `0`, but the Client has always supported logging `None` as a value so at the very least, it will support getting those `None`s back.
![Screen Shot 2019-08-29 at 9 18 11 AM](https://user-images.githubusercontent.com/7754936/63958000-57b87400-ca3e-11e9-84b2-a3cad9e31b4d.png)
![Screen Shot 2019-08-29 at 9 19 02 AM](https://user-images.githubusercontent.com/7754936/63957937-3788b500-ca3e-11e9-8759-3694f0cd8c59.png)