### PR TITLE
VR-2119: Implement model logging tests

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -47,32 +47,37 @@ def dev_key():
 
 
 @pytest.fixture
+def seed():
+    return RANDOM_SEED
+
+
+@pytest.fixture
 def nones():
     return [None]*INPUT_LENGTH
 
 
 @pytest.fixture
-def bools():
-    np.random.seed(RANDOM_SEED)
+def bools(seed):
+    np.random.seed(seed)
     return np.random.randint(0, 2, INPUT_LENGTH).astype(bool).tolist()
 
 
 @pytest.fixture
-def floats():
-    np.random.seed(RANDOM_SEED)
+def floats(seed):
+    np.random.seed(seed)
     return np.linspace(-3**2, 3**3, num=INPUT_LENGTH).tolist()
 
 
 @pytest.fixture
-def ints():
-    np.random.seed(RANDOM_SEED)
+def ints(seed):
+    np.random.seed(seed)
     return np.linspace(-3**4, 3**5, num=INPUT_LENGTH).astype(int).tolist()
 
 
 @pytest.fixture
-def strs():
+def strs(seed):
     """no duplicates"""
-    np.random.seed(RANDOM_SEED)
+    np.random.seed(seed)
     gen_str = lambda: ''.join(np.random.choice(list(string.ascii_letters), size=INPUT_LENGTH))
     result = set()
     while len(result) < INPUT_LENGTH:
@@ -85,8 +90,8 @@ def strs():
 
 
 @pytest.fixture
-def flat_lists(nones, bools, floats, ints, strs):
-    np.random.seed(RANDOM_SEED)
+def flat_lists(seed, nones, bools, floats, ints, strs):
+    np.random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     return [
         [
@@ -98,8 +103,8 @@ def flat_lists(nones, bools, floats, ints, strs):
 
 
 @pytest.fixture
-def flat_dicts(nones, bools, floats, ints, strs):
-    np.random.seed(RANDOM_SEED)
+def flat_dicts(seed, nones, bools, floats, ints, strs):
+    np.random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     return [
         {
@@ -111,8 +116,8 @@ def flat_dicts(nones, bools, floats, ints, strs):
 
 
 @pytest.fixture
-def nested_lists(nones, bools, floats, ints, strs):
-    np.random.seed(RANDOM_SEED)
+def nested_lists(seed, nones, bools, floats, ints, strs):
+    np.random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     flat_values = [value for type_values in values for value in type_values]
     def gen_value(p=1):
@@ -133,8 +138,8 @@ def nested_lists(nones, bools, floats, ints, strs):
 
 
 @pytest.fixture
-def nested_dicts(nones, bools, floats, ints, strs):
-    np.random.seed(RANDOM_SEED)
+def nested_dicts(seed, nones, bools, floats, ints, strs):
+    np.random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     flat_values = [value for type_values in values for value in type_values]
     def gen_value(p=1):

--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -179,10 +179,6 @@ class TestModels:
         # NOTE: weight states have weird shenanigans when model is saved
         # for weight, retrieved_weight in zip(net.weights, retrieved_net.weights):
 
-    def test_no_tensorflow(self, experiment_run, strs):
-        raise NotImplementedError
-        key = strs[0]
-
     def test_function(self, experiment_run, strs, flat_lists, flat_dicts):
         key = strs[0]
         func_args = flat_lists[0]

--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -120,12 +120,35 @@ class TestModels:
         key = strs[0]
 
     def test_function(self, experiment_run, strs, flat_lists, flat_dicts):
-        raise NotImplementedError
         key = strs[0]
+        func_args = flat_lists[0]
+        func_kwargs = flat_dicts[0]
+
+        def func(is_func=True, _cache=set([1, 2, 3]), *args, **kwargs):
+            return (args, kwargs)
+
+        experiment_run.log_model(key, func)
+        assert experiment_run.get_model(key).__defaults__ == func.__defaults__
+        assert experiment_run.get_model(key)(*func_args, **func_kwargs) == func(*func_args, **func_kwargs)
 
     def test_custom_class(self, experiment_run, strs, flat_lists, flat_dicts):
-        raise NotImplementedError
         key = strs[0]
+        init_args = flat_lists[0]
+        init_kwargs = flat_dicts[0]
+
+        class Custom:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+            def predict(self, data):
+                return (self.args, self.kwargs)
+
+        custom = Custom(*init_args, **init_kwargs)
+
+        experiment_run.log_model(key, custom)
+        assert experiment_run.get_model(key).__dict__ == custom.__dict__
+        assert experiment_run.get_model(key).predict(strs) == custom.predict(strs)
 
 
 class TestImages:

--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -117,6 +117,7 @@ class TestModels:
         key = strs[0]
         num_data_rows = 36
         X = torch.tensor(np.random.random((num_data_rows, 3, 32, 32)), dtype=torch.float)
+        y = torch.tensor(np.random.randint(10, size=num_data_rows), dtype=torch.long)
 
         class Model(nn.Module):
             def __init__(self):
@@ -138,6 +139,13 @@ class TestModels:
                 return x
 
         net = Model()
+        criterion = torch.nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(net.parameters())
+        for epoch in range(5):
+            y_pred = net(X)
+            loss = criterion(y_pred, y)
+            loss.backward()
+            optimizer.step()
 
         experiment_run.log_model(key, net)
         retrieved_net = experiment_run.get_model(key)


### PR DESCRIPTION
## Changelog
- add fixture to access `conftest.py`'s `RANDOM_SEED`
- add positive functionality tests for logging `sklearn`, `torch`, `keras`, functions, and custom models

## Notes
The following conceivable tests are not implemented:
- logging `xgboost`
- rejecting pure, non-`keras` `tensorflow`