### PR TITLE
Validate keys for Clientside querying

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1052,6 +1052,11 @@ class ExperimentRuns(object):
         -------
         :class:`ExperimentRuns`
 
+        Warnings
+        --------
+        This feature is still in active development. It is completely safe to use, but may exhibit
+        unintuitive behavior. Please report any oddities to the Verta team!
+
         Examples
         --------
         >>> runs.find(["hyperparameters.hidden_size == 256",
@@ -1145,6 +1150,11 @@ class ExperimentRuns(object):
         -------
         :class:`ExperimentRuns` or iterable of google.protobuf.message.Message
 
+        Warnings
+        --------
+        This feature is still in active development. It is completely safe to use, but may exhibit
+        unintuitive behavior. Please report any oddities to the Verta team!
+
         Examples
         --------
         >>> runs.sort("metrics.accuracy")
@@ -1193,6 +1203,11 @@ class ExperimentRuns(object):
         Returns
         -------
         :class:`ExperimentRuns` or iterable of google.protobuf.message.Message
+
+        Warnings
+        --------
+        This feature is still in active development. It is completely safe to use, but may exhibit
+        unintuitive behavior. Please report any oddities to the Verta team!
 
         Examples
         --------
@@ -1247,6 +1262,11 @@ class ExperimentRuns(object):
         Returns
         -------
         :class:`ExperimentRuns` or iterable of google.protobuf.message.Message
+
+        Warnings
+        --------
+        This feature is still in active development. It is completely safe to use, but may exhibit
+        unintuitive behavior. Please report any oddities to the Verta team!
 
         Examples
         --------

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -997,6 +997,13 @@ class ExperimentRuns(object):
                '<=': _CommonService.OperatorEnum.LTE}
     _OP_PATTERN = re.compile(r"({})".format('|'.join(sorted(six.viewkeys(_OP_MAP), key=lambda s: len(s), reverse=True))))
 
+    # keys that yield predictable, sensible results
+    _VALID_QUERY_KEYS = {
+        'id', 'project_id', 'experiment_id',
+        'date_created', 'date_updated', 'start_time', 'end_time',
+        'tags', 'attributes', 'hyperparameters', 'metrics',
+    }
+
     def __init__(self, conn, conf, expt_run_ids=None):
         self._conn = conn
         self._conf = conf
@@ -1077,6 +1084,10 @@ class ExperimentRuns(object):
                 six.raise_from(ValueError("predicate `{}` must be a two-operand comparison".format(predicate)),
                                None)
 
+            if key not in self._VALID_QUERY_KEYS:
+                raise ValueError("key `{}` is not a valid key for querying;"
+                                 " currently supported keys are: {}".format(key, self._VALID_QUERY_KEYS))
+
             # cast operator into protobuf enum variant
             operator = self._OP_MAP[operator]
 
@@ -1140,6 +1151,9 @@ class ExperimentRuns(object):
         <ExperimentRuns containing 3 runs>
 
         """
+        if key not in self._VALID_QUERY_KEYS:
+            raise ValueError("key `{}` is not a valid key for querying;"
+                             " currently supported keys are: {}".format(key, self._VALID_QUERY_KEYS))
         if self.__len__() == 0:
             return self.__class__(self._conn, self._conf)
 
@@ -1186,6 +1200,9 @@ class ExperimentRuns(object):
         <ExperimentRuns containing 3 runs>
 
         """
+        if key not in self._VALID_QUERY_KEYS:
+            raise ValueError("key `{}` is not a valid key for querying;"
+                             " currently supported keys are: {}".format(key, self._VALID_QUERY_KEYS))
         if _proj_id is not None and _expt_id is not None:
             raise ValueError("cannot specify both `_proj_id` and `_expt_id`")
         elif _proj_id is None and _expt_id is None:
@@ -1237,6 +1254,9 @@ class ExperimentRuns(object):
         <ExperimentRuns containing 3 runs>
 
         """
+        if key not in self._VALID_QUERY_KEYS:
+            raise ValueError("key `{}` is not a valid key for querying;"
+                             " currently supported keys are: {}".format(key, self._VALID_QUERY_KEYS))
         if _proj_id is not None and _expt_id is not None:
             raise ValueError("cannot specify both `_proj_id` and `_expt_id`")
         elif _proj_id is None and _expt_id is None:


### PR DESCRIPTION
Perform basic validation for Clientside querying keys because the back end currently does nothing.

This isn't meant to be exhaustive or permanent, but at the very least it catches typos on the user's end.

Then again, it doesn't point the user towards valid keys they can try, but I already wrote this so it's now a PR.