### PR TITLE
VR-2113: Implement Clientside Querying Tests

### DIFF
--- a/verta/tests/test_entities.py
+++ b/verta/tests/test_entities.py
@@ -1,10 +1,8 @@
 import itertools
-import random
 
 import requests
 
 import pytest
-import utils
 
 
 KWARGS = {
@@ -134,27 +132,29 @@ class TestExperimentRun:
 
 
 class TestExperimentRuns:
-    def test_magic_getitem(self, client):
+    def test_getitem(self, client):
         client.set_project()
         expt = client.set_experiment()
-        local_expt_run_ids = set()
 
-        local_expt_run_ids.update(client.set_experiment_run().id for _ in range(3))
-        backend_expt_run_ids = set(run.id for run in expt.expt_runs)
-        assert local_expt_run_ids == backend_expt_run_ids
+        # test for...in iteration
+        local_run_ids = set(client.set_experiment_run().id for _ in range(3))
+        assert local_run_ids == set(run.id for run in expt.expt_runs)
 
-        local_expt_run_ids.update(client.set_experiment_run().id for _ in range(3))
-        backend_expt_run_ids = set(run.id for run in expt.expt_runs)
-        assert local_expt_run_ids == backend_expt_run_ids
+        # do it again
+        local_run_ids.update(client.set_experiment_run().id for _ in range(3))
+        assert local_run_ids == set(run.id for run in expt.expt_runs)
 
-    def test_magic_len(self, client):
+        # direct __getitem__
+        assert expt.expt_runs[0].id in local_run_ids
+
+    def test_len(self, client):
         client.set_project()
         expt = client.set_experiment()
-        expt_run_ids = [client.set_experiment_run().id for _ in range(3)]
+        run_ids = [client.set_experiment_run().id for _ in range(3)]
 
-        assert len(expt_run_ids) == len(expt.expt_runs)
+        assert len(run_ids) == len(expt.expt_runs)
 
-    def test_magic_add(self, client):
+    def test_add(self, client):
         client.set_project()
         expt1 = client.set_experiment()
         local_expt1_run_ids = set(client.set_experiment_run().id for _ in range(3))
@@ -166,82 +166,3 @@ class TestExperimentRuns:
 
         # ignore duplicates
         assert local_expt1_run_ids == set(run.id for run in expt1.expt_runs + expt1.expt_runs)
-
-    def test_find(self, client):
-        client.set_project()
-        expt = client.set_experiment()
-
-        metric_vals = random.sample(range(36), 3)
-        hyperparam_vals = random.sample(range(36), 3)
-        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
-            run = client.set_experiment_run()
-            run.log_metric('val', metric_val)
-            run.log_hyperparameter('val', hyperparam_val)
-
-        threshold = random.choice(metric_vals)
-        local_filtered_run_ids = set(run.id for run in expt.expt_runs if run.get_metric('val') >= threshold)
-        backend_filtered_run_ids = set(run.id for run in expt.expt_runs.find("metrics.val >= {}".format(threshold)))
-        assert local_filtered_run_ids == backend_filtered_run_ids
-
-        threshold = random.choice(hyperparam_vals)
-        local_filtered_run_ids = set(run.id for run in expt.expt_runs if run.get_hyperparameter('val') >= threshold)
-        backend_filtered_run_ids = set(run.id for run in expt.expt_runs.find("hyperparameters.val >= {}".format(threshold)))
-        assert local_filtered_run_ids == backend_filtered_run_ids
-
-    def test_sort(self, client):
-        client.set_project()
-        expt = client.set_experiment()
-
-        vals = random.sample(range(36), 3)
-        for val in vals:
-            client.set_experiment_run().log_metric('val', val)
-
-        sorted_run_ids = [run.id for run in sorted(expt.expt_runs, key=lambda run: run.get_metric('val'))]
-        for expt_run_id, expt_run in zip(sorted_run_ids, expt.expt_runs.sort("metrics.val")):
-            assert expt_run_id == expt_run.id
-
-    def test_top_k(self, client):
-        client.set_project()
-        expt = client.set_experiment()
-
-        metric_vals = random.sample(range(36), 3)
-        hyperparam_vals = random.sample(range(36), 3)
-        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
-            run = client.set_experiment_run()
-            run.log_metric('val', metric_val)
-            run.log_hyperparameter('val', hyperparam_val)
-
-        k = random.randrange(3)
-        top_run_ids = [run.id for run in sorted(expt.expt_runs,
-                                                 key=lambda run: run.get_metric('val'), reverse=True)][:k]
-        for expt_run_id, expt_run in zip(top_run_ids, expt.expt_runs.top_k("metrics.val", k)):
-            assert expt_run_id == expt_run.id
-
-        k = random.randrange(3)
-        top_run_ids = [run.id for run in sorted(expt.expt_runs,
-                                                 key=lambda run: run.get_metric('val'), reverse=True)][:k]
-        for expt_run_id, expt_run in zip(top_run_ids, expt.expt_runs.top_k("metrics.val", k)):
-            assert expt_run_id == expt_run.id
-
-    def test_bottom_k(self, client):
-        client.set_project()
-        expt = client.set_experiment()
-
-        metric_vals = random.sample(range(36), 3)
-        hyperparam_vals = random.sample(range(36), 3)
-        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
-            run = client.set_experiment_run()
-            run.log_metric('val', metric_val)
-            run.log_hyperparameter('val', hyperparam_val)
-
-        k = random.randrange(3)
-        bottom_run_ids = [run.id for run in sorted(expt.expt_runs,
-                                                    key=lambda run: run.get_metric('val'))][:k]
-        for expt_run_id, expt_run in zip(bottom_run_ids, expt.expt_runs.bottom_k("metrics.val", k)):
-            assert expt_run_id == expt_run.id
-
-        k = random.randrange(3)
-        bottom_run_ids = [run.id for run in sorted(expt.expt_runs,
-                                                    key=lambda run: run.get_metric('val'))][:k]
-        for expt_run_id, expt_run in zip(bottom_run_ids, expt.expt_runs.bottom_k("metrics.val", k)):
-            assert expt_run_id == expt_run.id

--- a/verta/tests/test_query.py
+++ b/verta/tests/test_query.py
@@ -92,9 +92,26 @@ class TestFind:
     def test_end_time(self, client):
         key = "end_time"
 
-    @pytest.mark.skip(reason="not implemented")
-    def test_tags(self, client):
-        key = "tags"
+    def test_tags(self, client, seed, strs):
+        tags = strs[:5]
+        proj = client.set_project()
+        client.set_experiment()
+
+        for i in range(1, len(tags)+1):
+            client.set_experiment_run(tags=tags[:i])
+        expt_runs = proj.expt_runs
+
+        for tag in tags:
+            # contains tag
+            result = expt_runs.find("tags == '{}'".format(tag))
+            runs = [run for run in expt_runs if tag in run.get_tags()]
+            assert set(run.id for run in result) == set(run.id for run in runs)
+
+            # does not contain tag
+            result = expt_runs.find("tags != '{}'".format(tag))
+            runs = [run for run in expt_runs if tag not in run.get_tags()]
+            assert set(run.id for run in result) == set(run.id for run in runs)
+
 
     @pytest.mark.skip(reason="not implemented")
     def test_attributes(self, client):

--- a/verta/tests/test_query.py
+++ b/verta/tests/test_query.py
@@ -46,17 +46,35 @@ class TestFind:
                     with pytest.raises(ValueError):
                         expt_runs.find("{} {} {}".format(key, op, val))
 
-    @pytest.mark.skip(reason="not implemented")
     def test_id(self, client):
-        key = "id"
+        proj = client.set_project()
+        client.set_experiment()
+        runs = [client.set_experiment_run() for _ in range(3)]
 
-    @pytest.mark.skip(reason="not implemented")
-    def test_experiment_id(self, client):
-        key = "project_id"
+        for run_id in (run.id for run in runs):
+            result = proj.expt_runs.find("id == '{}'".format(run_id))
+            assert len(result) == 1
+            assert result[0].id == run_id
 
-    @pytest.mark.skip(reason="not implemented")
     def test_project_id(self, client):
-        key = "experiment_id"
+        proj = client.set_project()
+        client.set_experiment()
+        runs = [client.set_experiment_run() for _ in range(3)]
+        client.set_experiment()
+        runs.extend([client.set_experiment_run() for _ in range(3)])
+
+        result = proj.expt_runs.find("project_id == '{}'".format(proj.id))
+        assert set(run.id for run in result) == set(run.id for run in runs)
+
+    def test_experiment_id(self, client):
+        proj = client.set_project()
+        client.set_experiment()
+        [client.set_experiment_run() for _ in range(3)]
+        expt = client.set_experiment()
+        runs = [client.set_experiment_run() for _ in range(3)]
+
+        result = proj.expt_runs.find("experiment_id == '{}'".format(expt.id))
+        assert set(run.id for run in result) == set(run.id for run in runs)
 
     @pytest.mark.skip(reason="not implemented")
     def test_date_created(self, client):

--- a/verta/tests/test_query.py
+++ b/verta/tests/test_query.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+import pytest
+
+
+class TestQuery:
+    def test_find(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        metric_vals = random.sample(range(36), 3)
+        hyperparam_vals = random.sample(range(36), 3)
+        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
+            run = client.set_experiment_run()
+            run.log_metric('val', metric_val)
+            run.log_hyperparameter('val', hyperparam_val)
+
+        threshold = random.choice(metric_vals)
+        local_filtered_run_ids = set(run.id for run in expt.expt_runs if run.get_metric('val') >= threshold)
+        backend_filtered_run_ids = set(run.id for run in expt.expt_runs.find("metrics.val >= {}".format(threshold)))
+        assert local_filtered_run_ids == backend_filtered_run_ids
+
+        threshold = random.choice(hyperparam_vals)
+        local_filtered_run_ids = set(run.id for run in expt.expt_runs if run.get_hyperparameter('val') >= threshold)
+        backend_filtered_run_ids = set(run.id for run in expt.expt_runs.find("hyperparameters.val >= {}".format(threshold)))
+        assert local_filtered_run_ids == backend_filtered_run_ids
+
+    def test_sort(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        vals = random.sample(range(36), 3)
+        for val in vals:
+            client.set_experiment_run().log_metric('val', val)
+
+        sorted_run_ids = [run.id for run in sorted(expt.expt_runs, key=lambda run: run.get_metric('val'))]
+        for expt_run_id, expt_run in zip(sorted_run_ids, expt.expt_runs.sort("metrics.val")):
+            assert expt_run_id == expt_run.id
+
+    def test_top_k(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        metric_vals = random.sample(range(36), 3)
+        hyperparam_vals = random.sample(range(36), 3)
+        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
+            run = client.set_experiment_run()
+            run.log_metric('val', metric_val)
+            run.log_hyperparameter('val', hyperparam_val)
+
+        k = random.randrange(3)
+        top_run_ids = [run.id for run in sorted(expt.expt_runs,
+                                                 key=lambda run: run.get_metric('val'), reverse=True)][:k]
+        for expt_run_id, expt_run in zip(top_run_ids, expt.expt_runs.top_k("metrics.val", k)):
+            assert expt_run_id == expt_run.id
+
+        k = random.randrange(3)
+        top_run_ids = [run.id for run in sorted(expt.expt_runs,
+                                                 key=lambda run: run.get_metric('val'), reverse=True)][:k]
+        for expt_run_id, expt_run in zip(top_run_ids, expt.expt_runs.top_k("metrics.val", k)):
+            assert expt_run_id == expt_run.id
+
+    def test_bottom_k(self, client):
+        client.set_project()
+        expt = client.set_experiment()
+
+        metric_vals = random.sample(range(36), 3)
+        hyperparam_vals = random.sample(range(36), 3)
+        for metric_val, hyperparam_val in zip(metric_vals, hyperparam_vals):
+            run = client.set_experiment_run()
+            run.log_metric('val', metric_val)
+            run.log_hyperparameter('val', hyperparam_val)
+
+        k = random.randrange(3)
+        bottom_run_ids = [run.id for run in sorted(expt.expt_runs,
+                                                    key=lambda run: run.get_metric('val'))][:k]
+        for expt_run_id, expt_run in zip(bottom_run_ids, expt.expt_runs.bottom_k("metrics.val", k)):
+            assert expt_run_id == expt_run.id
+
+        k = random.randrange(3)
+        bottom_run_ids = [run.id for run in sorted(expt.expt_runs,
+                                                    key=lambda run: run.get_metric('val'))][:k]
+        for expt_run_id, expt_run in zip(bottom_run_ids, expt.expt_runs.bottom_k("metrics.val", k)):
+            assert expt_run_id == expt_run.id

--- a/verta/tests/test_query.py
+++ b/verta/tests/test_query.py
@@ -1,8 +1,99 @@
+import six
+
 import numpy as np
 
 import pytest
 
+import verta
 
+
+OPERATORS = six.viewkeys(verta.client.ExperimentRuns._OP_MAP)
+
+
+class TestFind:
+    def test_reject_unsupported_keys(self, client, floats):
+        keys = (
+            'name', 'description',
+            'code_version', 'code_version_snapshot',
+            'parent_id',
+            'artifacts', 'datasets',
+            'observations', 'features',
+            'job_id', 'owner',
+        )
+        proj = client.set_project()
+        expt = client.set_experiment()
+
+        for _ in range(3):
+            client.set_experiment_run()
+
+        # known unsupported keys
+        for expt_runs in (proj.expt_runs, expt.expt_runs):
+            for key in keys:
+                for op, val in zip(OPERATORS, floats):
+                    with pytest.raises(ValueError):
+                        expt_runs.find("{} {} {}".format(key, op, val))
+
+    def test_reject_random_keys(self, client, strs, floats):
+        proj = client.set_project()
+        expt = client.set_experiment()
+
+        for _ in range(3):
+            client.set_experiment_run()
+
+        for expt_runs in (proj.expt_runs, expt.expt_runs):
+            for key in strs:
+                for op, val in zip(OPERATORS, floats):
+                    with pytest.raises(ValueError):
+                        expt_runs.find("{} {} {}".format(key, op, val))
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_id(self, client):
+        key = "id"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_experiment_id(self, client):
+        key = "project_id"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_project_id(self, client):
+        key = "experiment_id"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_date_created(self, client):
+        key = "date_created"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_date_updated(self, client):
+        key = "date_updated"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_start_time(self, client):
+        key = "start_time"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_end_time(self, client):
+        key = "end_time"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_tags(self, client):
+        key = "tags"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_attributes(self, client):
+        key = "attributes"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_hyperparameters(self, client):
+        key = "hyperparameters"
+
+    @pytest.mark.skip(reason="not implemented")
+    def test_metrics(self, client, strs, bools, floats):
+        key = "metrics"
+        proj = client.set_project()
+        expt = client.set_experiment()
+
+
+@pytest.mark.skip(reason="obsolete")
 class TestQuery:
     def test_find(self, client):
         client.set_project()


### PR DESCRIPTION
I've reached a point where I believe the time it's taking to implement these tests is greater than the actual present value of this feature (I don't think anyone's relying on this functionality right now).

## Changelog
- revamp `verta::client::ExperimentRuns` magic method tests
- revamp tests for `find`, `sort`, `top_k`, and `bottom_k` for metrics and hyperparameters
- implement tests for `find` by ExperimentRun `id`, `experiment_id`, and `project_id`
- implement test for `find` by tags

## Notes
The following tests have *not* been implemented
- validation of dot-delimited keys e.g. `find` by `"metrics.acc"` allowed, but `find` by `"metrics"` not due to a lack of a metric key
- querying for attributes
  - tricky because attribute values can be collections
- querying for `created_time`, etc.
  - I doubt anyone is currently using this, and it requires providing a UNIX timestamp in millisecond resolution which is inherently pretty unfriendly for users.