### PR TITLE
VR-1913: Log code ver artifact path with .zip

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -686,11 +686,18 @@ class _ModelDBEntity(object):
                 zipf.write(exec_path, os.path.basename(exec_path))  # write as base filename
             zipstream.seek(0)
 
-            msg.code_version.code_archive.path = hashlib.sha256(zipstream.read()).hexdigest()
+            key = 'code'
+            extension = 'zip'
+
+            artifact_hash = hashlib.sha256(zipstream.read()).hexdigest()
             zipstream.seek(0)
+            basename = key + os.extsep + extension
+            artifact_path = os.path.join(artifact_hash, basename)
+
+            msg.code_version.code_archive.path = artifact_path
             msg.code_version.code_archive.path_only = False
             msg.code_version.code_archive.artifact_type = _CommonService.ArtifactTypeEnum.CODE
-            msg.code_version.code_archive.filename_extension = 'zip'
+            msg.code_version.code_archive.filename_extension = extension
         # TODO: check if we actually have any loggable information
         msg.code_version.date_logged = _utils.now()
 


### PR DESCRIPTION
This wasn't in the current sprint, but it was getting a bit annoying while testing code versioning.

## Changelog
- copy logic from `_log_artifact()` to `log_code()` to log file extension in `path`

## Examples
### Before:
![Screen Shot 2019-09-05 at 10 06 46 AM](https://user-images.githubusercontent.com/7754936/64363247-fad03700-cfc4-11e9-97f2-54f7ef2aad47.png)
### After:
![Screen Shot 2019-09-05 at 10 05 54 AM](https://user-images.githubusercontent.com/7754936/64363245-fa37a080-cfc4-11e9-8425-7aaf435881a3.png)
