### PR TITLE
VR-2117: Implement log_code() tests

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -194,7 +194,7 @@ def output_path():
 
 @pytest.fixture
 def client(host, port, email, dev_key):
-    client = Client(host, port, email, dev_key)
+    client = Client(host, port, email, dev_key, debug=True)
 
     yield client
 

--- a/verta/tests/test_log_code.py
+++ b/verta/tests/test_log_code.py
@@ -1,0 +1,86 @@
+import six
+
+import itertools
+import os
+import zipfile
+
+import pytest
+import utils
+
+
+class TestLogGit:
+    def test_log_git(self, client):
+        """git mode succeeds inside git repo"""
+        for mdb_entity in (client.set_project(), client.set_experiment(), client.set_experiment_run()):
+            mdb_entity._conf.use_git = True
+
+            mdb_entity.log_code()
+            code_version = mdb_entity.get_code()
+
+            assert isinstance(code_version, dict)
+            assert 'filepaths' in code_version
+            assert len(code_version['filepaths']) == 1
+            assert __file__.endswith(code_version['filepaths'][0])
+
+    def test_log_git_failure(self, client):
+        """git mode fails outside git repo"""
+        for mdb_entity in (client.set_project(), client.set_experiment(), client.set_experiment_run()):
+            mdb_entity._conf.use_git = True
+
+            with utils.chdir('/'):  # assuming the tester's root isn't a git repo
+                with pytest.raises(OSError):
+                    mdb_entity.log_code()
+
+    def test_log_git_provide_path(self, client):
+        for mdb_entity in (client.set_project(), client.set_experiment(), client.set_experiment_run()):
+            mdb_entity._conf.use_git = True
+
+            mdb_entity.log_code(exec_path="conftest.py")
+            code_version = mdb_entity.get_code()
+
+            assert isinstance(code_version, dict)
+            assert 'filepaths' in code_version
+            assert len(code_version['filepaths']) == 1
+            assert os.path.abspath("conftest.py").endswith(code_version['filepaths'][0])
+
+
+class TestLogSource:
+    def test_log_script(self, client):
+        """source mode succeeds for Python script"""
+        for mdb_entity in (client.set_project(), client.set_experiment(), client.set_experiment_run()):
+            mdb_entity._conf.use_git = False
+
+            mdb_entity.log_code()
+            zipf = mdb_entity.get_code()
+
+            assert isinstance(zipf, zipfile.ZipFile)
+            assert len(zipf.namelist()) == 1
+            assert __file__.endswith(zipf.namelist()[0])
+            assert open(__file__, 'rb').read() == zipf.open(zipf.infolist()[0]).read()
+
+    def test_log_script_provide_path(self, client):
+        for mdb_entity in (client.set_project(), client.set_experiment(), client.set_experiment_run()):
+            mdb_entity._conf.use_git = False
+
+            mdb_entity.log_code("conftest.py")
+            zipf = mdb_entity.get_code()
+
+            assert isinstance(zipf, zipfile.ZipFile)
+            assert len(zipf.namelist()) == 1
+            assert os.path.abspath("conftest.py").endswith(zipf.namelist()[0])
+            assert open("conftest.py", 'rb').read() == zipf.open(zipf.infolist()[0]).read()
+
+
+class TestConflict:
+    @pytest.mark.parametrize("order", itertools.product((True, False), repeat=2))
+    def test_log_conflict(self, client, order):
+        """only one code version, regardless of mode"""
+        first_mode, second_mode = order
+
+        for mdb_entity in (client.set_project(), client.set_experiment(), client.set_experiment_run()):
+            mdb_entity._conf.use_git = first_mode
+            mdb_entity.log_code()
+
+            mdb_entity._conf.use_git = second_mode
+            with pytest.raises(ValueError):
+                mdb_entity.log_code()

--- a/verta/tests/utils.py
+++ b/verta/tests/utils.py
@@ -1,4 +1,5 @@
 import random
+import os
 from string import printable
 
 import requests
@@ -82,6 +83,27 @@ def st_key_values(draw, min_size=1, max_size=12, scalars_only=False):
                                 st_scalars() if scalars_only else st_json(),
                                 min_size=min_size,
                                 max_size=max_size))
+
+
+class chdir:
+    """
+    Context manager for safely changing current working directory.
+
+    Without this context manager, if a test involving a directory change fails then subsequent tests
+    would likely fail as well due to a bad execution state.
+
+    """
+    def __init__(self, new_dir):
+        self.new_dir = new_dir
+        self.old_dir = None
+
+    def __enter__(self):
+        self.old_dir = os.getcwd()
+        os.chdir(self.new_dir)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        os.chdir(self.old_dir)
+        self.old_dir = None
 
 
 def delete_project(id_, conn):


### PR DESCRIPTION
These tests cover:
- successfully logging git in a repository
- rejecting logging git when not in a reposity
- successfully logging a `.py` source file

These tests do not cover:
- successfully logging a `.ipynb` source file because I can't run pytest inside a running Jupyter Notebook
- successfully logging a Google Colab notebook source file because I can't run pytest inside a Colab instance