### PR TITLE
Catch other unpickling errors

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2656,7 +2656,8 @@ class ExperimentRun(_ModelDBEntity):
         else:
             try:
                 return pickle.loads(artifact)
-            except pickle.UnpicklingError:
+            except (pickle.UnpicklingError,
+                    KeyError, ValueError):  # other unpickling errors
                 return six.BytesIO(artifact)
 
     def log_observation(self, key, value, timestamp=None):


### PR DESCRIPTION
I've discovered that passing CSV-like strings into `pickle.loads()` can somehow result in `KeyError`s and `ValueError`s. Thanks, Python.