### PR TITLE
Catch all errors from unpickling

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2663,8 +2663,7 @@ class ExperimentRun(_ModelDBEntity):
         else:
             try:
                 return pickle.loads(artifact)
-            except (pickle.UnpicklingError,
-                    KeyError, ValueError):  # other unpickling errors
+            except:
                 return six.BytesIO(artifact)
 
     def log_observation(self, key, value, timestamp=None):


### PR DESCRIPTION
I was hoping to avoid this, but then I got a `ModuleNotFound` error from unpickling a CSV string, so it looks like it can genuinely throw anything.