### PR TITLE
Rename model_id param to run_id

### DIFF
--- a/verta/docs/reference/api/deployment.rst
+++ b/verta/docs/reference/api/deployment.rst
@@ -2,5 +2,5 @@ Deployment
 ==========
 
 
-.. automodule:: verta.deployment
+.. autoclass:: verta.deployment.DeployedModel(host, run_id)
     :members:

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -48,29 +48,20 @@ class DeployedModel:
     <DeployedModel 01234567-0123-0123-0123-012345678901>
 
     """
-    def __init__(self, host=None, run_id=None, socket=None, model_id=None):
+    def __init__(self, **kwargs):
         # this is to temporarily maintain compatibility with anyone passing in `socket` and `model_id` as kwargs
-        # TODO v0.14.0: remove `socket` and `model_id` params
-        # TODO v0.14.0: remove default `None`s for `host` and `run_id` params
+        # TODO v0.14.0: instate `host` and `run_id` params
         # TODO v0.14.0: remove the following block of param checks
-        if all(param is None for param in (host, socket, run_id, model_id)):
-            raise TypeError("missing 2 required positional arguments: 'host' and 'run_id'")
-        if host is not None and socket is not None:
-            raise ValueError("cannot specify both `host` and `socket`; please only provide `host`")
-        elif host is None and socket is None:
-            raise TypeError("missing 1 required positional argument: 'host'")
-        elif host is None and socket is not None:
+        if kwargs.get('socket', None):
             warnings.warn("`socket` will be renamed to `host` in an upcoming version", category=FutureWarning)
-            host = socket
-            del socket
-        if run_id is not None and model_id is not None:
-            raise ValueError("cannot specify both `run_id` and `model_id`; please only provide `run_id`")
-        elif run_id is None and model_id is None:
-            raise TypeError("missing 1 required positional argument: 'run_id'")
-        elif run_id is None and model_id is not None:
+        if kwargs.get('model_id', None):
             warnings.warn("`model_id` will be renamed to `run_id` in an upcoming version", category=FutureWarning)
-            run_id = model_id
-            del model_id
+        host = kwargs.get('host', kwargs.get('socket', None))
+        run_id = kwargs.get('run_id', kwargs.get('model_id', None))
+        if host is None:
+            raise TypeError("missing required argument: `host`")
+        if run_id is None:
+            raise TypeError("missing required argument: `run_id`")
 
         self._session = requests.Session()
         self._session.headers.update({_GRPC_PREFIX+'source': "PythonClient"})

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -48,7 +48,7 @@ class DeployedModel:
     <DeployedModel 01234567-0123-0123-0123-012345678901>
 
     """
-    def __init__(self, **kwargs):
+    def __init__(self, _host=None, _run_id=None, **kwargs):
         # this is to temporarily maintain compatibility with anyone passing in `socket` and `model_id` as kwargs
         # TODO v0.14.0: instate `host` and `run_id` params
         # TODO v0.14.0: remove the following block of param checks
@@ -58,8 +58,8 @@ class DeployedModel:
         if 'model_id' in kwargs:
             warnings.warn("`model_id` will be renamed to `run_id` in an upcoming version",
                           category=FutureWarning)
-        host = kwargs.get('host', kwargs.get('socket'))
-        run_id = kwargs.get('run_id', kwargs.get('model_id'))
+        host = kwargs.get('host', kwargs.get('socket', _host))
+        run_id = kwargs.get('run_id', kwargs.get('model_id', _run_id))
         if host is None:
             raise TypeError("missing required argument: `host`")
         if run_id is None:

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -52,6 +52,7 @@ class DeployedModel:
         # this is to temporarily maintain compatibility with anyone passing in `socket` and `model_id` as kwargs
         # TODO v0.14.0: instate `host` and `run_id` params
         # TODO v0.14.0: remove the following block of param checks
+        # TODO v0.14.0: put automodule verta.deployment back on ReadTheDocs
         if 'socket' in kwargs:
             warnings.warn("`socket` will be renamed to `host` in an upcoming version",
                           category=FutureWarning)

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -52,12 +52,14 @@ class DeployedModel:
         # this is to temporarily maintain compatibility with anyone passing in `socket` and `model_id` as kwargs
         # TODO v0.14.0: instate `host` and `run_id` params
         # TODO v0.14.0: remove the following block of param checks
-        if kwargs.get('socket', None):
-            warnings.warn("`socket` will be renamed to `host` in an upcoming version", category=FutureWarning)
-        if kwargs.get('model_id', None):
-            warnings.warn("`model_id` will be renamed to `run_id` in an upcoming version", category=FutureWarning)
-        host = kwargs.get('host', kwargs.get('socket', None))
-        run_id = kwargs.get('run_id', kwargs.get('model_id', None))
+        if 'socket' in kwargs:
+            warnings.warn("`socket` will be renamed to `host` in an upcoming version",
+                          category=FutureWarning)
+        if 'model_id' in kwargs:
+            warnings.warn("`model_id` will be renamed to `run_id` in an upcoming version",
+                          category=FutureWarning)
+        host = kwargs.get('host', kwargs.get('socket'))
+        run_id = kwargs.get('run_id', kwargs.get('model_id'))
         if host is None:
             raise TypeError("missing required argument: `host`")
         if run_id is None:


### PR DESCRIPTION
This is for the new public `verta::deployment::DeployedModel`.

`model_id` makes no sense; `run_id` is more in line with Client terminology.