### PR TITLE
VR-2301: Remove bin_boundaries and reference_counts from state

### DIFF
--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -86,6 +86,13 @@ class HistogramProcessor(ProcessorBase):
     """
     Object for processing histogram states and handling new inputs.
 
+    """
+
+
+class FloatHistogramProcessor(HistogramProcessor):
+    """
+    :class:`HistogramProcessor` for continuous data.
+
     Parameters
     ----------
     feature_name : str
@@ -103,7 +110,7 @@ class HistogramProcessor(ProcessorBase):
         kwargs['feature_name'] = feature_name
         kwargs['bin_boundaries'] = bin_boundaries
         kwargs['reference_counts'] = reference_counts
-        super(HistogramProcessor, self).__init__(**kwargs)
+        super(FloatHistogramProcessor, self).__init__(**kwargs)
 
     def new_state(self):
         """
@@ -230,14 +237,6 @@ class HistogramProcessor(ProcessorBase):
         return state_info
 
 
-class FloatHistogramProcessor(HistogramProcessor):
-    """
-    :class:`HistogramProcessor` for continuous data.
-
-    """
-    pass
-
-
 class BinaryHistogramProcessor(HistogramProcessor):
     """
     :class:`HistogramProcessor` for binary data.
@@ -255,7 +254,6 @@ class BinaryHistogramProcessor(HistogramProcessor):
             raise ValueError("`reference_counts` must contain exactly two elements")
 
         kwargs['feature_name'] = feature_name
-        kwargs['bin_boundaries'] = [0, .5, 1+1e-15]  # this isn't used by this subclass
         kwargs['reference_counts'] = reference_counts
         super(BinaryHistogramProcessor, self).__init__(**kwargs)
 

--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -154,16 +154,6 @@ class FloatHistogramProcessor(HistogramProcessor):
             feature_val = input[feature_name]
         except KeyError:
             six.raise_from(KeyError("key '{}' not found in `input`".format(feature_name)), None)
-        except TypeError:  # input is list instead of dict
-            try:
-                feature_index = self.config['feature_index']
-            except KeyError:
-                six.raise_from(RuntimeError("`input` is a list, but this Processor"
-                                            " doesn't have an index for its feature"), None)
-            try:
-                feature_val = input[feature_index]
-            except IndexError:
-                six.raise_from(IndexError("index '{}' out of bounds for `input`".format(feature_index)), None)
 
         # fold feature value into state
         lower_bounds = [float('-inf')] + self.config['bin_boundaries']
@@ -270,16 +260,6 @@ class BinaryHistogramProcessor(HistogramProcessor):
             feature_val = input[feature_name]
         except KeyError:
             six.raise_from(KeyError("key '{}' not found in `input`".format(feature_name)), None)
-        except TypeError:  # input is list instead of dict
-            try:
-                feature_index = self.config['feature_index']
-            except KeyError:
-                six.raise_from(RuntimeError("`input` is a list, but this Processor"
-                                            " doesn't have an index for its feature"), None)
-            try:
-                feature_val = input[feature_index]
-            except IndexError:
-                six.raise_from(IndexError("index '{}' out of bounds for `input`".format(feature_index)), None)
 
         # fold feature value into state
         for bin, category in zip(state['bins'], self.config['bin_categories']):


### PR DESCRIPTION
## Changelog
- `HistogramProcessor` logic has been moved entirely to `FloatHistogramProcessor`
- `bin_boundaries` and `reference_counts` are now tracked solely in the `Processor`'s `config`.
- `reduce_states()` and `get_from_state()` are commented out for now.
- `BinaryHistogramProcessor` now takes a much more categorical approach.