### PR TITLE
VR-2332: Implement Missing Data Processors

### DIFF
--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -478,3 +478,13 @@ class BinaryInputHistogramProcessor(_BinaryHistogramProcessor):
 class BinaryPredictionHistogramProcessor(_BinaryHistogramProcessor):
     def reduce_on_prediction(self, state, prediction):
         return self._reduce_data(state, prediction)
+
+
+class MissingInputHistogramProcessor(_MissingHistogramProcessor):
+    def reduce_on_input(self, state, input):
+        return self._reduce_data(state, input)
+
+
+class MissingPredictionHistogramProcessor(_MissingHistogramProcessor):
+    def reduce_on_prediction(self, state, prediction):
+        return self._reduce_data(state, prediction)

--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -411,36 +411,39 @@ class _MissingHistogramProcessor(_HistogramProcessor):
 
     def _reduce_data(self, state, data):
         # increment processor call count
-        state['bins'][1] += 1
+        state['call_count'] += 1
 
         feature_val = self._get_feature_value(data)
 
         # increment feature presence count
         if feature_val is None:
-            state['bins'][0] += 1
+            state['feature_count'] += 1
 
         return state
 
     def new_state(self):
         state = {}
 
-        # initialize empty bins
-        state['bins'] = [
-            0,  # number of times feature is present
-            0,  # number of times processor is called
-        ]
+        state['call_count'] = 0  # number of times processor is called
+        state['feature_count'] = 0  # number of times feature is present
 
         return state
+
+    def reduce_states(self, state1, state2):
+        state1['call_count'] += state2['call_count']
+        state1['feature_count'] += state2['feature_count']
+
+        return state1
 
     def get_from_state(self, state):
         if not state:
             state = self.new_state()
 
         value = {}
-        if state['bins'][1] == 0:
+        if state['call_count'] == 0:
             value['live'] = 0
         else:
-            value['live'] = (state['bins'][0]/state['bins'][1])*100
+            value['live'] = (state['feature_count']/state['call_count'])*100
         if self.config['reference_proportion'] is not None:
             value['reference'] = self.config['reference_proportion']*100
 

--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -386,13 +386,13 @@ class _BinaryHistogramProcessor(_DiscreteHistogramProcessor):
 
 class _MissingHistogramProcessor(_HistogramProcessor):
     """
-    :class:`HistogramProcessor` for tracking how often a feature value is missing from data.
+    :class:`HistogramProcessor` for tracking how often a feature value is present in data.
 
     Parameters
     ----------
     reference_proportion : float, optional
-        Proportion of missing values for the feature in a reference distribution. This value cannot
-        be greater than 1.
+        Proportion of how often the feature is present in a reference distribution. This value
+        cannot be greater than 1.
     feature_name : str : optional
         Name of the feature to track in the histogram.
     feature_index : int, optional
@@ -416,7 +416,7 @@ class _MissingHistogramProcessor(_HistogramProcessor):
         feature_val = self._get_feature_value(data)
 
         # increment feature presence count
-        if feature_val is None:
+        if feature_val is not None:
             state['feature_count'] += 1
 
         return state

--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -390,22 +390,22 @@ class _MissingHistogramProcessor(_HistogramProcessor):
 
     Parameters
     ----------
-    feature_name : str
-        Name of the feature to track in the histogram.
     reference_proportion : float, optional
         Proportion of missing values for the feature in a reference distribution. This value cannot
         be greater than 1.
+    feature_name : str : optional
+        Name of the feature to track in the histogram.
     feature_index : int, optional
         Index of the feature for when the data is passed as a list instead of a dictionary.
 
     """
-    def __init__(self, feature_name, reference_proportion=None, feature_index=None, **kwargs):
+    def __init__(self, reference_proportion=None, feature_name=None, feature_index=None, **kwargs):
         if (reference_proportion is not None
                 and reference_proportion > 1):
             raise ValueError("`reference_proportion` cannot be greater than 1")
 
-        kwargs['feature_name'] = feature_name
         kwargs['reference_proportion'] = reference_proportion
+        kwargs['feature_name'] = feature_name
         kwargs['feature_index'] = feature_index
         super(_MissingHistogramProcessor, self).__init__(**kwargs)
 


### PR DESCRIPTION
## Notes
- `__init__()` takes a _proportion_ (<=1) for reference. This is to make sure the user gives it the correct value.
  - If I allowed >1, then there's no way to check if the user is entering the proportion or accidentally the percentage. Only allowing <=1 means I can enforce that only the proportion is possible.
  - This number is converted to a <=100 percentage on `get_from_state()`.

## Examples
![Screen Shot 2019-10-01 at 10 49 18 AM](https://user-images.githubusercontent.com/7754936/65986671-2fef6e00-e439-11e9-91e9-f96517aad94f.png)
