### PR TITLE
[on hold] Remove [-1] limits from _FloatHistogramProcessor.get_from_state()

### DIFF
--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -253,7 +253,7 @@ class _FloatHistogramProcessor(_HistogramProcessor):
         histogram['live'] = state['bins']
         if self.config['reference_counts'] is not None:
             histogram['reference'] = [0] + self.config['reference_counts'] + [0]
-        histogram['bucket_limits'] = [-1] + self.config['bin_boundaries'] + [-1]
+        histogram['bucket_limits'] = self.config['bin_boundaries']
 
         return {
             'type': "float",


### PR DESCRIPTION
In accordance with [VR-2331](https://vertaai.atlassian.net/browse/VR-2331)'s description, and because using `-1` as a special value for _arbitrary floats_ is problematic!!