### PR TITLE
Handle Scalar Data in Processors

### DIFF
--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2468,7 +2468,7 @@ class ExperimentRun(_ModelDBEntity):
             for col_i, col_name in enumerate(train_targets):
                 col = train_df[col_name]
 
-                # if model API says output is scalar, don't assigning index or name
+                # if model API says output is scalar, don't assign index or name
                 if model_api.to_dict()['output']['type'] not in ("VertaList", "VertaJson"):
                     feature_index = feature_name = None
                 else:

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2467,14 +2467,21 @@ class ExperimentRun(_ModelDBEntity):
             # create PredictionHistogramProcessors
             for col_i, col_name in enumerate(train_targets):
                 col = train_df[col_name]
+
+                # if model API says output is scalar, don't assigning index or name
+                if model_api.to_dict()['output']['type'] not in ("VertaList", "VertaJson"):
+                    feature_index = feature_name = None
+                else:
+                    feature_index, feature_name = col_i, col_name
+
                 if col.dtype.name.startswith(('int', 'float')):
                     if set(col.unique()) == {0, 1}:
                         reference_counts = [sum(col == 0), sum(col == 1)]
-                        processors[col_name] = monitoring.BinaryPredictionHistogramProcessor(reference_counts, feature_name=col_name, feature_index=col_i)
+                        processors[col_name] = monitoring.BinaryPredictionHistogramProcessor(reference_counts, feature_name=feature_name, feature_index=feature_index)
                     else:
                         bin_boundaries = monitoring.calculate_bin_boundaries(col)
                         reference_counts = monitoring.calculate_reference_counts(col, bin_boundaries)
-                        processors[col_name] = monitoring.FloatPredictionHistogramProcessor(bin_boundaries, reference_counts, feature_name=col_name, feature_index=col_i)
+                        processors[col_name] = monitoring.FloatPredictionHistogramProcessor(bin_boundaries, reference_counts, feature_name=feature_name, feature_index=feature_index)
                 else:
                     continue  # ignore non-numeric columns for now
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2450,11 +2450,11 @@ class ExperimentRun(_ModelDBEntity):
                 if col.dtype.name.startswith(('int', 'float')):
                     if set(col.unique()) == {0, 1}:
                         reference_counts = [sum(col == 0), sum(col == 1)]
-                        processors[col_name] = monitoring.BinaryInputHistogramProcessor(col_name, reference_counts, feature_index=col_i)
+                        processors[col_name] = monitoring.BinaryInputHistogramProcessor(reference_counts, feature_name=col_name, feature_index=col_i)
                     else:
                         bin_boundaries = monitoring.calculate_bin_boundaries(col)
                         reference_counts = monitoring.calculate_reference_counts(col, bin_boundaries)
-                        processors[col_name] = monitoring.FloatInputHistogramProcessor(col_name, bin_boundaries, reference_counts, feature_index=col_i)
+                        processors[col_name] = monitoring.FloatInputHistogramProcessor(bin_boundaries, reference_counts, feature_name=col_name, feature_index=col_i)
                 else:
                     continue  # ignore non-numeric columns for now
 
@@ -2470,11 +2470,11 @@ class ExperimentRun(_ModelDBEntity):
                 if col.dtype.name.startswith(('int', 'float')):
                     if set(col.unique()) == {0, 1}:
                         reference_counts = [sum(col == 0), sum(col == 1)]
-                        processors[col_name] = monitoring.BinaryPredictionHistogramProcessor(col_name, reference_counts, feature_index=col_i)
+                        processors[col_name] = monitoring.BinaryPredictionHistogramProcessor(reference_counts, feature_name=col_name, feature_index=col_i)
                     else:
                         bin_boundaries = monitoring.calculate_bin_boundaries(col)
                         reference_counts = monitoring.calculate_reference_counts(col, bin_boundaries)
-                        processors[col_name] = monitoring.FloatPredictionHistogramProcessor(col_name, bin_boundaries, reference_counts, feature_index=col_i)
+                        processors[col_name] = monitoring.FloatPredictionHistogramProcessor(bin_boundaries, reference_counts, feature_name=col_name, feature_index=col_i)
                 else:
                     continue  # ignore non-numeric columns for now
 

--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -177,24 +177,24 @@ class _FloatHistogramProcessor(_HistogramProcessor):
 
     Parameters
     ----------
-    feature_name : str
-        Name of the feature to track in the histogram.
     bin_boundaries : list of float of length N+1
         Boundaries for the histogram's N bins.
     reference_counts : list of int of length N, optional
         Counts for a precomputed reference distribution.
+    feature_name : str, optional
+        Name of the feature to track in the histogram.
     feature_index : int, optional
         Index of the feature for when the data is passed as a list instead of a dictionary.
 
     """
-    def __init__(self, feature_name, bin_boundaries, reference_counts=None, feature_index=None, **kwargs):
+    def __init__(self, bin_boundaries, reference_counts=None, feature_name=None, feature_index=None, **kwargs):
         if (reference_counts is not None
                 and len(bin_boundaries) - 1 != len(reference_counts)):
             raise ValueError("`bin_boundaries` must be one element longer than `reference_counts`")
 
-        kwargs['feature_name'] = feature_name
         kwargs['bin_boundaries'] = bin_boundaries
         kwargs['reference_counts'] = reference_counts
+        kwargs['feature_name'] = feature_name
         kwargs['feature_index'] = feature_index
         super(_FloatHistogramProcessor, self).__init__(**kwargs)
 
@@ -261,24 +261,24 @@ class _DiscreteHistogramProcessor(_HistogramProcessor):
 
     Parameters
     ----------
-    feature_name : str
-        Name of the feature to track in the histogram.
     bin_categories : list of length N
         Category values for the histogram's bins.
     reference_counts : list of int of length N, optional
         Counts for a precomputed reference distribution.
+    feature_name : str, optional
+        Name of the feature to track in the histogram.
     feature_index : int, optional
         Index of the feature for when the data is passed as a list instead of a dictionary.
 
     """
-    def __init__(self, feature_name, bin_categories, reference_counts=None, feature_index=None, **kwargs):
+    def __init__(self, bin_categories, reference_counts=None, feature_name=None, feature_index=None, **kwargs):
         if (reference_counts is not None
                 and len(bin_categories) != len(reference_counts)):
             raise ValueError("`bin_boundaries` and `reference_counts` must have the same length")
 
-        kwargs['feature_name'] = feature_name
         kwargs['bin_categories'] = bin_categories
         kwargs['reference_counts'] = reference_counts
+        kwargs['feature_name'] = feature_name
         kwargs['feature_index'] = feature_index
         super(_DiscreteHistogramProcessor, self).__init__(**kwargs)
 
@@ -355,22 +355,22 @@ class _BinaryHistogramProcessor(_DiscreteHistogramProcessor):
 
     Parameters
     ----------
-    feature_name : str
-        Name of the feature to track in the histogram.
     reference_counts : list of int of length 2, optional
         Counts for a precomputed reference distribution.
+    feature_name : str, optional
+        Name of the feature to track in the histogram.
     feature_index : int, optional
         Index of the feature for when the data is passed as a list instead of a dictionary.
 
     """
-    def __init__(self, feature_name, reference_counts=None, feature_index=None, **kwargs):
+    def __init__(self, reference_counts=None, feature_name=None, feature_index=None, **kwargs):
         if (reference_counts is not None
                 and len(reference_counts) != 2):
             raise ValueError("`reference_counts` must contain exactly two elements")
 
-        kwargs['feature_name'] = feature_name
         kwargs['bin_categories'] = [0, 1]
         kwargs['reference_counts'] = reference_counts
+        kwargs['feature_name'] = feature_name
         kwargs['feature_index'] = feature_index
         super(_BinaryHistogramProcessor, self).__init__(**kwargs)
 

--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -81,7 +81,7 @@ class _BaseProcessor(object):
         ----------
         state : dict
             Current state of the histogram.
-        input : dict
+        input : JSON
             JSON data containing the feature value.
 
         Returns
@@ -100,7 +100,7 @@ class _BaseProcessor(object):
         ----------
         state : dict
             Current state of the histogram.
-        prediction : dict
+        prediction : JSON
             JSON data containing the feature value.
 
         Returns
@@ -213,6 +213,8 @@ class _FloatHistogramProcessor(_HistogramProcessor):
             except IndexError:
                 six.raise_from(IndexError("index '{}' out of bounds for"
                                           " data of length {}".format(feature_index, len(data))), None)
+        elif feature_name is None and feature_index is None:  # probably intentional scalar
+            feature_val = data
         else:
             raise TypeError("data {} is neither a dict nor a list".format(data))
         if feature_val is None:  # missing data
@@ -297,6 +299,8 @@ class _DiscreteHistogramProcessor(_HistogramProcessor):
             except IndexError:
                 six.raise_from(IndexError("index '{}' out of bounds for"
                                           " data of length {}".format(feature_index, len(data))), None)
+        elif feature_name is None and feature_index is None:  # probably intentional scalar
+            feature_val = data
         else:
             raise TypeError("data {} is neither a dict nor a list".format(data))
         if feature_val is None:  # missing data

--- a/verta/verta/monitoring.py
+++ b/verta/verta/monitoring.py
@@ -81,7 +81,7 @@ class _BaseProcessor(object):
         ----------
         state : dict
             Current state of the histogram.
-        input : JSON
+        input : JSON object
             JSON data containing the feature value.
 
         Returns
@@ -100,7 +100,7 @@ class _BaseProcessor(object):
         ----------
         state : dict
             Current state of the histogram.
-        prediction : JSON
+        prediction : JSON object
             JSON data containing the feature value.
 
         Returns


### PR DESCRIPTION
## Context
Sometimes, `data` might just be a scalar, rather than a list of values. 

## Changes
- make `feature_name` optional in `Processor`s
- in `log_model_for_deployment()`, if modelAPI says output is not list or dict, then set name and index to `None` to signal that `Processor` should expect a scalar