### PR TITLE
VR-2496: Use NamedTemporaryFiles to handle (de)serializing Keras

### DIFF
--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -86,7 +86,6 @@ class TestArtifacts:
                 experiment_run.log_artifact(key, artifact)
 
 
-@pytest.mark.skipif(six.PY2, reason="run.get_model() doesn't work in Python 2")
 class TestModels:
     def test_sklearn(self, seed, experiment_run, strs):
         np.random.seed(seed)

--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -9,7 +9,6 @@ import verta
 
 
 class TestLogModelForDeployment:
-    @pytest.mark.skipif(six.PY2, reason="run.get_model() doesn't work in Python 2")
     def test_model(self, experiment_run, model_for_deployment):
         experiment_run.log_model_for_deployment(**model_for_deployment)
         retrieved_model = experiment_run.get_model("model.pkl")


### PR DESCRIPTION
## Context
TensorFlow v1.15 was released yesterday, which rejects bytestreams for saving/loading Keras models and instead now only accepts filenames as arguments.

This issue may sound familiar—it was also present in older versions of TensorFlow and H5py.

## Changes
For Keras (de)serialization, I use a `NamedTemporaryFile` instead of a `BytesIO`.

## Examples
Left is Python 3 & TensorFlow==1.15
Right is Python 2 & TensorFlow==1.13
### Before
<img width="1436" alt="Screen Shot 2019-10-17 at 4 36 05 PM" src="https://user-images.githubusercontent.com/7754936/67055256-3ac62600-f0fc-11e9-9cd5-fd5b77e75739.png">

### After
<img width="1437" alt="Screen Shot 2019-10-17 at 4 32 50 PM" src="https://user-images.githubusercontent.com/7754936/67055190-ed49b900-f0fb-11e9-8cae-1d180bed6df0.png">
