### PR TITLE
Decouple test configuration

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -6,7 +6,6 @@ import os
 import shutil
 import string
 
-from google.cloud import bigquery
 import numpy as np
 
 import verta
@@ -24,10 +23,6 @@ DEFAULT_HOST = None
 DEFAULT_PORT = None
 DEFAULT_EMAIL = None
 DEFAULT_DEV_KEY = None
-
-DEFAULT_S3_TEST_BUCKET = "bucket"
-DEFAULT_S3_TEST_OBJECT = "object"
-DEFAULT_GOOGLE_APPLICATION_CREDENTIALS = "credentials.json"
 
 
 # hypothesis on Jenkins is apparently too slow
@@ -227,27 +222,3 @@ def created_datasets(client):
 
     if created_datasets:
         utils.delete_datasets(list(set(dataset.id for dataset in created_datasets)), client._conn)
-
-
-@pytest.fixture(scope='session')
-def s3_bucket():
-    return os.environ.get("VERTA_S3_TEST_BUCKET", DEFAULT_S3_TEST_BUCKET)
-
-
-@pytest.fixture(scope='session')
-def s3_object():
-    return os.environ.get("VERTA_S3_TEST_OBJECT", DEFAULT_S3_TEST_OBJECT)
-
-
-@pytest.fixture(scope='session')
-def bq_query():
-    return (
-        "SELECT id, `by`, score, time, time_ts, title, url, text, deleted, dead, descendants, author"
-        " FROM `bigquery-public-data.hacker_news.stories`"
-        " LIMIT 1000"
-    )
-
-
-@pytest.fixture(scope='session')
-def bq_location():
-    return "US"

--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -8,9 +8,6 @@ import string
 
 from google.cloud import bigquery
 import numpy as np
-import pandas as pd
-import sklearn
-from sklearn import linear_model
 
 import verta
 from verta import Client
@@ -254,22 +251,3 @@ def bq_query():
 @pytest.fixture(scope='session')
 def bq_location():
     return "US"
-
-
-@pytest.fixture
-def model_for_deployment(strs):
-    num_rows, num_cols = 36, 6
-
-    data = pd.DataFrame(np.tile(np.arange(num_rows).reshape(-1, 1),
-                                num_cols),
-                        columns=strs[:num_cols])
-    X_train = data.iloc[:,:-1]  # pylint: disable=bad-whitespace
-    y_train = data.iloc[:, -1]
-
-    return {
-        'model': sklearn.linear_model.LogisticRegression(),
-        'model_api': verta.utils.ModelAPI(X_train, y_train),
-        'requirements': six.StringIO("scikit-learn=={}".format(sklearn.__version__)),
-        'train_features': X_train,
-        'train_targets': y_train,
-    }

--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -3,10 +3,9 @@ from __future__ import division
 import six
 
 import os
+import random
 import shutil
 import string
-
-import numpy as np
 
 import verta
 from verta import Client
@@ -62,27 +61,27 @@ def nones():
 
 @pytest.fixture
 def bools(seed):
-    np.random.seed(seed)
-    return np.random.randint(0, 2, INPUT_LENGTH).astype(bool).tolist()
+    random.seed(seed)
+    return [bool(random.randint(0, 1)) for _ in range(INPUT_LENGTH)]
 
 
 @pytest.fixture
 def floats(seed):
-    np.random.seed(seed)
-    return np.linspace(-3**2, 3**3, num=INPUT_LENGTH).tolist()
+    random.seed(seed)
+    return [random.uniform(-3**2, 3**3) for _ in range(INPUT_LENGTH)]
 
 
 @pytest.fixture
 def ints(seed):
-    np.random.seed(seed)
-    return np.linspace(-3**4, 3**5, num=INPUT_LENGTH).astype(int).tolist()
+    random.seed(seed)
+    return [random.randint(-3**4, 3**5) for _ in range(INPUT_LENGTH)]
 
 
 @pytest.fixture
 def strs(seed):
     """no duplicates"""
-    np.random.seed(seed)
-    gen_str = lambda: ''.join(np.random.choice(list(string.ascii_letters), size=INPUT_LENGTH))
+    random.seed(seed)
+    gen_str = lambda: ''.join(random.choice(string.ascii_letters) for _ in range(INPUT_LENGTH))
     result = set()
     while len(result) < INPUT_LENGTH:
         single_str = gen_str()
@@ -95,11 +94,11 @@ def strs(seed):
 
 @pytest.fixture
 def flat_lists(seed, nones, bools, floats, ints, strs):
-    np.random.seed(seed)
+    random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     return [
         [
-            values[np.random.choice(len(values))][i]
+            values[random.choice(range(len(values)))][i]
             for i in range(INPUT_LENGTH)
         ]
         for _ in range(INPUT_LENGTH)
@@ -108,11 +107,11 @@ def flat_lists(seed, nones, bools, floats, ints, strs):
 
 @pytest.fixture
 def flat_dicts(seed, nones, bools, floats, ints, strs):
-    np.random.seed(seed)
+    random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     return [
         {
-            strs[i]: values[np.random.choice(len(values))][i]
+            strs[i]: values[random.choice(range(len(values)))][i]
             for i in range(INPUT_LENGTH)
         }
         for _ in range(INPUT_LENGTH)
@@ -121,21 +120,21 @@ def flat_dicts(seed, nones, bools, floats, ints, strs):
 
 @pytest.fixture
 def nested_lists(seed, nones, bools, floats, ints, strs):
-    np.random.seed(seed)
+    random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     flat_values = [value for type_values in values for value in type_values]
     def gen_value(p=1):
-        if np.random.random() < p:
+        if random.random() < p:
             return [
                 gen_value(p/2)
-                for _ in range(np.random.choice(4))
+                for _ in range(random.choice(range(4)))
             ]
         else:
-            return np.random.choice(flat_values)
+            return random.choice(flat_values)
     return [
         [
             gen_value()
-            for _ in range(np.random.choice(3)+1)
+            for _ in range(random.choice(range(3))+1)
         ]
         for _ in range(INPUT_LENGTH)
     ]
@@ -143,21 +142,21 @@ def nested_lists(seed, nones, bools, floats, ints, strs):
 
 @pytest.fixture
 def nested_dicts(seed, nones, bools, floats, ints, strs):
-    np.random.seed(seed)
+    random.seed(seed)
     values = (nones, bools, floats, ints, strs)
     flat_values = [value for type_values in values for value in type_values]
     def gen_value(p=1):
-        if np.random.random() < p:
+        if random.random() < p:
             return {
                 key: gen_value(p/2)
-                for key, _ in zip(strs, range(np.random.choice(4)))
+                for key, _ in zip(strs, range(random.choice(range(4))))
             }
         else:
-            return np.random.choice(flat_values)
+            return random.choice(flat_values)
     return [
         {
             key: gen_value()
-            for key, _ in zip(strs, range(np.random.choice(3)+1))
+            for key, _ in zip(strs, range(random.choice(range(3))+1))
         }
         for _ in range(INPUT_LENGTH)
     ]

--- a/verta/tests/modelapi_hypothesis/test_modelapi.py
+++ b/verta/tests/modelapi_hypothesis/test_modelapi.py
@@ -1,4 +1,9 @@
+import pytest
+
 import json
+
+pytest.importorskip("numpy")
+pytest.importorskip("pandas")
 
 from verta.utils import ModelAPI
 

--- a/verta/tests/modelapi_hypothesis/test_value_generator.py
+++ b/verta/tests/modelapi_hypothesis/test_value_generator.py
@@ -1,6 +1,11 @@
+import pytest
+
 import six
 
 import numbers
+
+pytest.importorskip("numpy")
+pytest.importorskip("pandas")
 
 import hypothesis
 from value_generator import api_and_values, series_api_and_values, dataframe_api_and_values

--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -1,23 +1,25 @@
+import pytest
+
 import six
 
 import os
 import sys
 
-import matplotlib
+matplotlib = pytest.importorskip("matplotlib")
 matplotlib.use("Agg")  # https://stackoverflow.com/a/37605654
 import matplotlib.pyplot as plt
-import numpy as np
-import PIL
+np = pytest.importorskip("numpy")
+PIL = pytest.importorskip("PIL")
 import PIL.ImageDraw
-import sklearn
+sklearn = pytest.importorskip("sklearn")
 from sklearn import cluster, naive_bayes, pipeline, preprocessing
+tensorflow = pytest.importorskip("tensorflow")
 from tensorflow import keras
-import torch
+torch = pytest.importorskip("torch")
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 
-import pytest
 import utils
 
 

--- a/verta/tests/test_datasets.py
+++ b/verta/tests/test_datasets.py
@@ -1,14 +1,15 @@
+import pytest
+
 import six
 
-import numpy as np
 import os
 import time
 import shutil
 
-import botocore
-import google
+np = pytest.importorskip("numpy")
+botocore = pytest.importorskip("botocore")
+google = pytest.importorskip("google")
 
-import pytest
 import utils
 
 from verta._dataset import Dataset, DatasetVersion, S3DatasetVersionInfo, FilesystemDatasetVersionInfo

--- a/verta/tests/test_datasets.py
+++ b/verta/tests/test_datasets.py
@@ -16,6 +16,35 @@ from verta._protos.public.modeldb import DatasetService_pb2 as _DatasetService
 from verta._protos.public.modeldb import DatasetVersionService_pb2 as _DatasetVersionService
 
 
+DEFAULT_S3_TEST_BUCKET = "bucket"
+DEFAULT_S3_TEST_OBJECT = "object"
+DEFAULT_GOOGLE_APPLICATION_CREDENTIALS = "credentials.json"
+
+
+@pytest.fixture(scope='session')
+def s3_bucket():
+    return os.environ.get("VERTA_S3_TEST_BUCKET", DEFAULT_S3_TEST_BUCKET)
+
+
+@pytest.fixture(scope='session')
+def s3_object():
+    return os.environ.get("VERTA_S3_TEST_OBJECT", DEFAULT_S3_TEST_OBJECT)
+
+
+@pytest.fixture(scope='session')
+def bq_query():
+    return (
+        "SELECT id, `by`, score, time, time_ts, title, url, text, deleted, dead, descendants, author"
+        " FROM `bigquery-public-data.hacker_news.stories`"
+        " LIMIT 1000"
+    )
+
+
+@pytest.fixture(scope='session')
+def bq_location():
+    return "US"
+
+
 class TestBaseDatasets:
     def test_creation_from_scratch(self, client, created_datasets):
         name = utils.gen_str()

--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -1,16 +1,16 @@
+import pytest
+
 import six
 
 import json
 import os
 
-import numpy as np
-import pandas as pd
-import sklearn
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+sklearn = pytest.importorskip("sklearn")
 from sklearn import linear_model
 
 import verta
-
-import pytest
 
 
 @pytest.fixture

--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -3,9 +3,33 @@ import six
 import json
 import os
 
-import pytest
+import numpy as np
+import pandas as pd
+import sklearn
+from sklearn import linear_model
 
 import verta
+
+import pytest
+
+
+@pytest.fixture
+def model_for_deployment(strs):
+    num_rows, num_cols = 36, 6
+
+    data = pd.DataFrame(np.tile(np.arange(num_rows).reshape(-1, 1),
+                                num_cols),
+                        columns=strs[:num_cols])
+    X_train = data.iloc[:,:-1]  # pylint: disable=bad-whitespace
+    y_train = data.iloc[:, -1]
+
+    return {
+        'model': sklearn.linear_model.LogisticRegression(),
+        'model_api': verta.utils.ModelAPI(X_train, y_train),
+        'requirements': six.StringIO("scikit-learn=={}".format(sklearn.__version__)),
+        'train_features': X_train,
+        'train_targets': y_train,
+    }
 
 
 class TestLogModelForDeployment:

--- a/verta/tests/test_query.py
+++ b/verta/tests/test_query.py
@@ -1,7 +1,5 @@
 import six
 
-import numpy as np
-
 import pytest
 
 import verta
@@ -92,7 +90,7 @@ class TestFind:
     def test_end_time(self, client):
         key = "end_time"
 
-    def test_tags(self, client, seed, strs):
+    def test_tags(self, client, strs):
         tags = strs[:5]
         proj = client.set_project()
         client.set_experiment()


### PR DESCRIPTION
## Motivation
I'd like to run comprehensive Client tests to verify that `verta` works without `grpcio`.

## Problem
Some third-party scientific package used during pytests—not sure which—has `grpcio` as a dependency.
I drew this conclusion from [this Jenkins job](https://jenkins.dev.verta.ai/job/client/job/run-pytest/242/consoleFull) that removed `grpcio` as a Client dependency, but it still installed it anyway.

## Solution
Tests and imports/configurations need to be decoupled slightly, so that "basic" pytests can be run even if third-party packages are not available.
- move third-party package imports and fixtures to the test scripts that use them
- skip those test scripts if those packages are not installed
- replace `np.random` in `conftest.py` with the stdlib `random`