### PR TITLE
Shift import checks further into test functions

### DIFF
--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -5,21 +5,6 @@ import six
 import os
 import sys
 
-matplotlib = pytest.importorskip("matplotlib")
-matplotlib.use("Agg")  # https://stackoverflow.com/a/37605654
-import matplotlib.pyplot as plt
-np = pytest.importorskip("numpy")
-PIL = pytest.importorskip("PIL")
-import PIL.ImageDraw
-sklearn = pytest.importorskip("sklearn")
-from sklearn import cluster, naive_bayes, pipeline, preprocessing
-tensorflow = pytest.importorskip("tensorflow")
-from tensorflow import keras
-torch = pytest.importorskip("torch")
-import torch.nn as nn
-import torch.nn.functional as F
-import torch.optim as optim
-
 import utils
 
 
@@ -90,6 +75,10 @@ class TestArtifacts:
 
 class TestModels:
     def test_sklearn(self, seed, experiment_run, strs):
+        np = pytest.importorskip("numpy")
+        sklearn = pytest.importorskip("sklearn")
+        from sklearn import cluster, naive_bayes, pipeline, preprocessing
+
         np.random.seed(seed)
         key = strs[0]
         num_data_rows = 36
@@ -114,6 +103,12 @@ class TestModels:
             assert step[1].get_params() == retrieved_step[1].get_params()  # step model
 
     def test_torch(self, seed, experiment_run, strs):
+        np = pytest.importorskip("numpy")
+        torch = pytest.importorskip("torch")
+        import torch.nn as nn
+        import torch.nn.functional as F
+        import torch.optim as optim
+
         np.random.seed(seed)
         key = strs[0]
         num_data_rows = 36
@@ -158,6 +153,10 @@ class TestModels:
             assert torch.allclose(weight, retrieved_net.state_dict()[key])
 
     def test_keras(self, seed, experiment_run, strs):
+        np = pytest.importorskip("numpy")
+        tensorflow = pytest.importorskip("tensorflow")
+        from tensorflow import keras
+
         np.random.seed(seed)
         key = strs[0]
         num_data_rows = 36
@@ -223,6 +222,8 @@ class TestModels:
 class TestImages:
     @staticmethod
     def matplotlib_to_pil(fig):
+        PIL = pytest.importorskip("PIL")
+
         bytestream = six.BytesIO()
         fig.savefig(bytestream)
         return PIL.Image.open(bytestream)
@@ -240,6 +241,8 @@ class TestImages:
             experiment_run.get_image(holdout)
 
     def test_upload_blank_warning(self, experiment_run, strs):
+        PIL = pytest.importorskip("PIL")
+
         key = strs[0]
         img = PIL.Image.new('RGB', (64, 64), 'white')
 
@@ -247,6 +250,11 @@ class TestImages:
             experiment_run.log_image(key, img)
 
     def test_upload_plt(self, experiment_run, strs):
+        np = pytest.importorskip("numpy")
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")  # https://stackoverflow.com/a/37605654
+        import matplotlib.pyplot as plt
+
         key = strs[0]
         plt.scatter(*np.random.random((2, 10)))
 
@@ -255,6 +263,11 @@ class TestImages:
                               np.asarray(self.matplotlib_to_pil(plt).getdata()))
 
     def test_upload_fig(self, experiment_run, strs):
+        np = pytest.importorskip("numpy")
+        matplotlib = pytest.importorskip("matplotlib")
+        matplotlib.use("Agg")  # https://stackoverflow.com/a/37605654
+        import matplotlib.pyplot as plt
+
         key = strs[0]
         fig, ax = plt.subplots()
         ax.scatter(*np.random.random((2, 10)))
@@ -264,6 +277,10 @@ class TestImages:
                               np.asarray(self.matplotlib_to_pil(fig).getdata()))
 
     def test_upload_pil(self, experiment_run, strs):
+        np = pytest.importorskip("numpy")
+        PIL = pytest.importorskip("PIL")
+        import PIL.ImageDraw
+
         key = strs[0]
         img = PIL.Image.new('RGB', (64, 64), 'gray')
         PIL.ImageDraw.Draw(img).arc(np.r_[np.random.randint(32, size=(2)),
@@ -276,6 +293,8 @@ class TestImages:
                               np.asarray(img.getdata())))
 
     def test_conflict(self, experiment_run, strs):
+        PIL = pytest.importorskip("PIL")
+
         images = dict(zip(strs, [PIL.Image.new('RGB', (64, 64), 'gray')]*3))
 
         for key, image in six.viewitems(images):

--- a/verta/tests/test_datasets.py
+++ b/verta/tests/test_datasets.py
@@ -6,10 +6,6 @@ import os
 import time
 import shutil
 
-np = pytest.importorskip("numpy")
-botocore = pytest.importorskip("botocore")
-google = pytest.importorskip("google")
-
 import utils
 
 from verta._dataset import Dataset, DatasetVersion, S3DatasetVersionInfo, FilesystemDatasetVersionInfo
@@ -384,6 +380,8 @@ class TestFileSystemDatasetVersionInfo:
 
 class TestS3DatasetVersionInfo:
     def test_single_object(self, s3_bucket, s3_object):
+        botocore = pytest.importorskip("botocore")
+
         try:
             s3dvi = S3DatasetVersionInfo(s3_bucket, s3_object)
             assert len(s3dvi.dataset_part_infos) == 1
@@ -392,6 +390,8 @@ class TestS3DatasetVersionInfo:
             pytest.skip("insufficient AWS credentials")
 
     def test_bucket(self, s3_bucket):
+        botocore = pytest.importorskip("botocore")
+
         try:
             s3dvi = S3DatasetVersionInfo(s3_bucket)
             assert len(s3dvi.dataset_part_infos) >= 1
@@ -402,6 +402,8 @@ class TestS3DatasetVersionInfo:
 
 class TestS3ClientFunctions:
     def test_s3_dataset_creation(self, client, created_datasets):
+        botocore = pytest.importorskip("botocore")
+
         try:
             name = utils.gen_str()
             dataset = client.set_dataset("s3-" + name, type="s3")
@@ -411,6 +413,8 @@ class TestS3ClientFunctions:
             pytest.skip("insufficient AWS credentials")
 
     def test_s3_dataset_version_creation(self, client, s3_bucket, created_datasets):
+        botocore = pytest.importorskip("botocore")
+
         try:
             name = utils.gen_str()
             dataset = client.set_dataset("s3-" + name, type="s3")
@@ -459,6 +463,9 @@ class TestBigQueryDatasetVersionInfo:
         assert dataset.dataset_type == _DatasetService.DatasetTypeEnum.QUERY
 
     def test_big_query_dataset_version_creation(self, client, bq_query, bq_location, created_datasets):
+        google = pytest.importorskip("google")
+        bigquery = pytest.importorskip("google.cloud.bigquery")
+
         try:
             query_job = google.cloud.bigquery.Client().query(
                 bq_query,
@@ -496,6 +503,8 @@ class TestRDBMSDatasetVersionInfo:
 
 class TestLogDatasetVersion:
     def test_log_dataset_version(self, client, created_datasets, experiment_run, s3_bucket):
+        botocore = pytest.importorskip("botocore")
+
         try:
             name = utils.gen_str()
             dataset = client.set_dataset("s3-" + name, type="s3")

--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -5,16 +5,16 @@ import six
 import json
 import os
 
-np = pytest.importorskip("numpy")
-pd = pytest.importorskip("pandas")
-sklearn = pytest.importorskip("sklearn")
-from sklearn import linear_model
-
 import verta
 
 
 @pytest.fixture
 def model_for_deployment(strs):
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    sklearn = pytest.importorskip("sklearn")
+    from sklearn import linear_model
+
     num_rows, num_cols = 36, 6
 
     data = pd.DataFrame(np.tile(np.arange(num_rows).reshape(-1, 1),


### PR DESCRIPTION
Enables simple data versioning and artifact tests to run without unnecessary third-party libraries.

<img width="1436" alt="Screen Shot 2019-10-29 at 4 56 54 PM" src="https://user-images.githubusercontent.com/7754936/67818080-2c1d2e80-fa6d-11e9-81d7-57de57d29bd8.png">
<img width="1437" alt="Screen Shot 2019-10-29 at 4 57 06 PM" src="https://user-images.githubusercontent.com/7754936/67818081-2c1d2e80-fa6d-11e9-823b-5960122e2aa4.png">
