### PR TITLE
Implement log_requirements()

### DIFF
--- a/verta/docs/reference/api/experimentrun.rst
+++ b/verta/docs/reference/api/experimentrun.rst
@@ -116,4 +116,6 @@ Deployment
 ^^^^^^^^^^
 .. automethod:: ExperimentRun.log_model_for_deployment
 .. automethod:: ExperimentRun.log_modules
+
+.. automethod:: ExperimentRun.log_requirements
 .. automethod:: ExperimentRun.log_setup_script

--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -4,6 +4,7 @@ import six
 
 import json
 import os
+import tempfile
 
 import verta
 
@@ -79,3 +80,101 @@ class TestLogModelForDeployment:
         X_train = model_for_deployment['train_features']
         y_train = model_for_deployment['train_targets']
         assert X_train.join(y_train).to_csv(index=False) == six.ensure_str(data_csv)
+
+
+class TestLogRequirements:
+    NONSPECIFIC_REQ = "verta>0.1.0"
+    INVALID_REQ = "@==1.2.3"
+    UNIMPORTABLE_REQ = "bananacoconut"
+    VERTA_MISMATCH_REQ = "verta==0.0.0"
+    CLOUDPICKLE_MISMATCH_REQ = "cloudpickle==0.0.0"
+    VALID_REQS = [
+        'cloudpickle',
+        'pytest',
+        'verta',
+    ]
+
+    def test_nonspecific_ver_list_warning(self, experiment_run):
+        with pytest.warns(UserWarning):
+            experiment_run.log_requirements([self.NONSPECIFIC_REQ])
+
+    def test_nonspecific_ver_file_warning(self, experiment_run):
+        with tempfile.NamedTemporaryFile('w+') as tempf:
+            tempf.write(self.NONSPECIFIC_REQ)
+            tempf.seek(0)
+
+            with pytest.warns(UserWarning):
+                experiment_run.log_requirements(tempf.name)
+
+    def test_invalid_pkg_name_list_error(self, experiment_run):
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements([self.INVALID_REQ])
+
+    def test_invalid_pkg_name_file_error(self, experiment_run):
+        with tempfile.NamedTemporaryFile('w+') as tempf:
+            tempf.write(self.INVALID_REQ)
+            tempf.seek(0)
+
+            with pytest.raises(ValueError):
+                experiment_run.log_requirements(tempf.name)
+
+    def test_unimportable_pkg_list_error(self, experiment_run):
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements([self.UNIMPORTABLE_REQ])
+
+    def test_unimportable_pkg_file_error(self, experiment_run):
+        with tempfile.NamedTemporaryFile('w+') as tempf:
+            tempf.write(self.UNIMPORTABLE_REQ)
+            tempf.seek(0)
+
+            with pytest.raises(ValueError):
+                experiment_run.log_requirements(tempf.name)
+
+    def test_verta_ver_mismatch_list_error(self, experiment_run):
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements([self.VERTA_MISMATCH_REQ])
+
+    def test_verta_ver_mismatch_file_error(self, experiment_run):
+        with tempfile.NamedTemporaryFile('w+') as tempf:
+            tempf.write(self.VERTA_MISMATCH_REQ)
+            tempf.seek(0)
+
+            with pytest.raises(ValueError):
+                experiment_run.log_requirements(tempf.name)
+
+    def test_cloudpickle_ver_mismatch_list_error(self, experiment_run):
+        with pytest.raises(ValueError):
+            experiment_run.log_requirements([self.CLOUDPICKLE_MISMATCH_REQ])
+
+    def test_cloudpickle_ver_mismatch_file_error(self, experiment_run):
+        with tempfile.NamedTemporaryFile('w+') as tempf:
+            tempf.write(self.CLOUDPICKLE_MISMATCH_REQ)
+            tempf.seek(0)
+
+            with pytest.raises(ValueError):
+                experiment_run.log_requirements(tempf.name)
+
+    def test_injection(self, experiment_run):
+        experiment_run.log_requirements([])
+
+        reqs_txt = experiment_run.get_artifact("requirements.txt").read().decode()
+        reqs = set(req.split('==')[0].strip() for req in reqs_txt.splitlines())
+        assert {'cloudpickle', 'verta'} == reqs
+
+    def test_list(self, experiment_run):
+        experiment_run.log_requirements(self.VALID_REQS)
+
+        reqs_txt = experiment_run.get_artifact("requirements.txt").read().decode()
+        reqs = set(req.split('==')[0].strip() for req in reqs_txt.splitlines())
+        assert set(self.VALID_REQS) == reqs
+
+    def test_file(self, experiment_run):
+        with tempfile.NamedTemporaryFile('w+') as tempf:
+            tempf.write('\n'.join(self.VALID_REQS))
+            tempf.seek(0)
+
+            experiment_run.log_requirements(tempf.name)
+
+        reqs_txt = experiment_run.get_artifact("requirements.txt").read().decode()
+        reqs = set(req.split('==')[0].strip() for req in reqs_txt.splitlines())
+        assert set(self.VALID_REQS) == reqs

--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -154,8 +154,16 @@ class TestLogRequirements:
             with pytest.raises(ValueError):
                 experiment_run.log_requirements(tempf.name)
 
-    def test_injection(self, experiment_run):
+    def test_injection_list(self, experiment_run):
         experiment_run.log_requirements([])
+
+        reqs_txt = experiment_run.get_artifact("requirements.txt").read().decode()
+        reqs = set(req.split('==')[0].strip() for req in reqs_txt.splitlines())
+        assert {'cloudpickle', 'verta'} == reqs
+
+    def test_injection_file(self, experiment_run):
+        with tempfile.NamedTemporaryFile('w+') as tempf:
+            experiment_run.log_requirements(tempf.name)
 
         reqs_txt = experiment_run.get_artifact("requirements.txt").read().decode()
         reqs = set(req.split('==')[0].strip() for req in reqs_txt.splitlines())

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -303,11 +303,6 @@ def process_requirements(requirements):
     }
     REQ_SPEC_REGEX = re.compile(r"([a-zA-Z0-9._-]+)(.*)?")  # https://www.python.org/dev/peps/pep-0508/#names
 
-    # clean up requirements
-    requirements = [req.strip() for req in requirements]
-    requirements = [req for req in requirements if not req.startswith('#')]  # comment line
-    requirements = [req for req in requirements if req]  # empty line
-
     # validate package names
     for req in requirements:
         if not REQ_SPEC_REGEX.match(req):
@@ -323,9 +318,8 @@ def process_requirements(requirements):
         elif '==' in ver_spec:
             continue
         else:
-            msg = ("'{}' does not use '==';"
-                   " for reproducibility in deployment,"
-                   " it will be replaced with an exact version pin".format(req))
+            msg = ("'{}' does not use '=='; for reproducibility in deployment, it will be replaced"
+                   " with an exact pin for the currently-installed version".format(req))
             warnings.warn(msg)
             requirements[i] = pkg
 
@@ -348,7 +342,7 @@ def process_requirements(requirements):
             except AttributeError:
                 six.raise_from(error, None)
 
-            requirements[i] = mod_name + "==" + ver
+            requirements[i] = req + "==" + ver
 
     # add verta
     verta_req = "verta=={}".format(__about__.__version__)

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -319,7 +319,7 @@ def process_requirements(requirements):
             continue
         else:
             msg = ("'{}' does not use '=='; for reproducibility in deployment, it will be replaced"
-                   " with an exact pin for the currently-installed version".format(req))
+                   " with an exact pin of the currently-installed version".format(req))
             warnings.warn(msg)
             requirements[i] = pkg
 

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -4,13 +4,17 @@ import six
 import six.moves.cPickle as pickle
 
 import csv
+import importlib
 import json
 import os
+import re
 import tempfile
+import warnings
 
 import cloudpickle
 
-from verta import _utils
+from . import __about__
+from . import _utils
 
 try:
     import joblib
@@ -278,14 +282,14 @@ def deserialize_model(bytestring):
     return bytestream
 
 
-def validate_requirements_txt(requirements):
+def process_requirements(requirements):
     """
-    Checks that all dependencies listed in `requirements` have an exact version pin.
+    Validates `requirements` against packages available in the current environment.
 
     Parameters
     ----------
-    requirements : file-like
-        pip requirements file.
+    requirements : list of str
+        PyPI package names.
 
     Raises
     ------
@@ -293,10 +297,85 @@ def validate_requirements_txt(requirements):
         If a listed dependency does not have an exact version pin.
 
     """
-    reset_stream(requirements)  # reset cursor to beginning in case user forgot
-    contents = requirements.read()
-    reset_stream(requirements)  # reset cursor to beginning as a courtesy
+    PYPI_TO_IMPORT = {
+        'scikit-learn': "sklearn",
+        'tensorflow-gpu': "tensorflow",
+    }
+    REQ_SPEC_REGEX = re.compile(r"([a-zA-Z0-9._-]+)(.*)?")  # https://www.python.org/dev/peps/pep-0508/#names
 
-    for dependency in six.ensure_str(contents).split("\n"):
-        if dependency and '==' not in dependency:
-            raise ValueError("dependency '{}' must have an exact version pin".format(dependency))
+    # clean up requirements
+    requirements = [req.strip() for req in requirements]
+    requirements = [req for req in requirements if not req.startswith('#')]  # comment line
+    requirements = [req for req in requirements if req]  # empty line
+
+    # validate package names
+    for req in requirements:
+        if not REQ_SPEC_REGEX.match(req):
+            raise ValueError("'{}' does not appear to be a valid PyPI-installable package;"
+                             " please check its spelling,"
+                             " or report this as a bug if you believe it is in error".format(req))
+
+    # warn for and strip version specifiers other than ==
+    for i, req in enumerate(requirements):
+        pkg, ver_spec = REQ_SPEC_REGEX.match(req).groups()
+        if not ver_spec:
+            continue
+        elif '==' in ver_spec:
+            continue
+        else:
+            msg = ("'{}' does not use '==';"
+                   " for reproducibility in deployment,"
+                   " it will be replaced with an exact version pin".format(req))
+            warnings.warn(msg)
+            requirements[i] = pkg
+
+    # find version numbers from importable packages
+    #     Because Python package management is complete anarchy, the Client can't determine
+    #     whether the environment is using pip, pip3, or conda to check the installed version.
+    for i, req in enumerate(requirements):
+        error = ValueError("unable to determine a version number for requirement '{}';"
+                           " please manually specify it as '{}==x.y.z'".format(req, req))
+        if '==' not in req:
+            mod_name = PYPI_TO_IMPORT.get(req, req)
+
+            # obtain package version
+            try:
+                mod = importlib.import_module(mod_name)
+            except ImportError:
+                six.raise_from(error, None)
+            try:
+                ver = mod.__version__
+            except AttributeError:
+                six.raise_from(error, None)
+
+            requirements[i] = mod_name + "==" + ver
+
+    # add verta
+    verta_req = "verta=={}".format(__about__.__version__)
+    for req in requirements:
+        if req.startswith("verta"):  # if present, check version
+            our_ver = verta_req.split('==')[-1]
+            their_ver = req.split('==')[-1]
+            if our_ver != their_ver:  # versions conflict, so raise exception
+                raise ValueError("Client is running with verta v{}, but the provided requirements specify v{};"
+                                 " these must match".format(our_ver, their_ver))
+            else:  # versions match, so proceed
+                break
+    else:  # if not present, add
+        requirements.append(verta_req)
+
+    # add cloudpickle
+    cloudpickle_req = "cloudpickle=={}".format(cloudpickle.__version__)
+    for req in requirements:
+        if req.startswith("cloudpickle"):  # if present, check version
+            our_ver = cloudpickle_req.split('==')[-1]
+            their_ver = req.split('==')[-1]
+            if our_ver != their_ver:  # versions conflict, so raise exception
+                raise ValueError("Client is running with cloudpickle v{}, but the provided requirements specify v{};"
+                                 " these must match".format(our_ver, their_ver))
+            else:  # versions match, so proceed
+                break
+    else:  # if not present, add
+        requirements.append(cloudpickle_req)
+
+    return requirements

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -294,7 +294,7 @@ def process_requirements(requirements):
     Raises
     ------
     ValueError
-        If a package's version cannot be determined.
+        If a package's name is invalid for PyPI, or its exact version cannot be determined.
 
     """
     PYPI_TO_IMPORT = {

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -308,7 +308,7 @@ def process_requirements(requirements):
         if not REQ_SPEC_REGEX.match(req):
             raise ValueError("'{}' does not appear to be a valid PyPI-installable package;"
                              " please check its spelling,"
-                             " or report this as a bug if you believe it is in error".format(req))
+                             " or file an issue if you believe it is in error".format(req))
 
     # warn for and strip version specifiers other than ==
     for i, req in enumerate(requirements):

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -294,7 +294,7 @@ def process_requirements(requirements):
     Raises
     ------
     ValueError
-        If a listed dependency does not have an exact version pin.
+        If a package's version cannot be determined.
 
     """
     PYPI_TO_IMPORT = {

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -27,6 +27,17 @@ except ImportError:  # TensorFlow not installed
     pass
 
 
+# for process_requirements()
+PYPI_TO_IMPORT = {
+    'scikit-learn': "sklearn",
+    'tensorflow-gpu': "tensorflow",
+}
+IMPORT_TO_PYPI = {  # separate mapping because PyPI to import is surjective
+    'sklearn': "scikit-learn",
+}
+REQ_SPEC_REGEX = re.compile(r"([a-zA-Z0-9._-]+)(.*)?")  # https://www.python.org/dev/peps/pep-0508/#names
+
+
 def get_file_ext(file):
     """
     Obtain the filename extension of `file`.
@@ -297,12 +308,6 @@ def process_requirements(requirements):
         If a package's name is invalid for PyPI, or its exact version cannot be determined.
 
     """
-    PYPI_TO_IMPORT = {
-        'scikit-learn': "sklearn",
-        'tensorflow-gpu': "tensorflow",
-    }
-    REQ_SPEC_REGEX = re.compile(r"([a-zA-Z0-9._-]+)(.*)?")  # https://www.python.org/dev/peps/pep-0508/#names
-
     # validate package names
     for req in requirements:
         if not REQ_SPEC_REGEX.match(req):

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2863,7 +2863,7 @@ class ExperimentRun(_ModelDBEntity):
             jupyter==1.0.0
             matplotlib==3.1.1
             pandas==0.25.0
-            sklearn==0.21.3
+            scikit-learn==0.21.3
             verta==0.14.0
 
         From a list of package names:
@@ -2873,16 +2873,22 @@ class ExperimentRun(_ModelDBEntity):
             >>> print(run.get_artifact("requirements.txt").read().decode())
             verta==0.14.0
             cloudpickle==1.2.1
-            sklearn==0.21.3
+            scikit-learn==0.21.3
 
         """
         if isinstance(requirements, six.string_types):
             with open(requirements, 'r') as f:
                 requirements = f.readlines()
+            # clean
+            requirements = [req.strip() for req in requirements]
+            requirements = [req for req in requirements if not req.startswith('#')]  # comment line
+            requirements = [req for req in requirements if req]  # empty line
         elif (isinstance(requirements, list)
               and all(isinstance(req, six.string_types) for req in requirements)):
-            # TODO: replace scikit-learn with sklearn
-            pass
+            # replace importable module names with PyPI package names
+            for i, req in enumerate(requirements):
+                if req.strip() == "sklearn":
+                    requirements[i] = "scikit-learn"
         else:
             raise TypeError("`requirements` must be either str or list of str, not {}".format(type(requirements)))
 

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -5,6 +5,7 @@ import six.moves.cPickle as pickle
 from six.moves.urllib.parse import urlparse
 
 import ast
+import copy
 import hashlib
 import importlib
 import os
@@ -2852,6 +2853,11 @@ class ExperimentRun(_ModelDBEntity):
                   for upload.
                 - If list of str, then it will be interpreted as a list of PyPI package names.
 
+        Raises
+        ------
+        ValueError
+            If a package's name is invalid for PyPI, or its exact version cannot be determined.
+
         Examples
         --------
         From a file:
@@ -2879,12 +2885,15 @@ class ExperimentRun(_ModelDBEntity):
         if isinstance(requirements, six.string_types):
             with open(requirements, 'r') as f:
                 requirements = f.readlines()
+
             # clean
             requirements = [req.strip() for req in requirements]
             requirements = [req for req in requirements if not req.startswith('#')]  # comment line
             requirements = [req for req in requirements if req]  # empty line
         elif (isinstance(requirements, list)
               and all(isinstance(req, six.string_types) for req in requirements)):
+            requirements = copy.copy(requirements)
+
             # replace importable module names with PyPI package names
             for i, req in enumerate(requirements):
                 if req.strip() == "sklearn":

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2843,10 +2843,12 @@ class ExperimentRun(_ModelDBEntity):
         """
         Logs a pip requirements file for Verta model deployment.
 
+        .. versionadded:: 0.14.0
+
         Parameters
         ----------
         requirements : str or list of str
-            pip-installable packages necessary to deploy the model
+            pip-installable packages necessary to deploy the model.
                 - If str, then it will be interpreted as a filesystem path to a requirements file
                   for upload.
                 - If list of str, then it will be interpreted as a list of pip package names.

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -2874,7 +2874,7 @@ class ExperimentRun(_ModelDBEntity):
 
         From a list of package names:
 
-            >>> run.log_requirements(['verta', 'cloudpickle', 'sklearn'])
+            >>> run.log_requirements(['verta', 'cloudpickle', 'scikit-learn'])
             upload complete (requirements.txt)
             >>> print(run.get_artifact("requirements.txt").read().decode())
             verta==0.14.0
@@ -2894,10 +2894,9 @@ class ExperimentRun(_ModelDBEntity):
               and all(isinstance(req, six.string_types) for req in requirements)):
             requirements = copy.copy(requirements)
 
-            # replace importable module names with PyPI package names
+            # replace importable module names with PyPI package names in case of user error
             for i, req in enumerate(requirements):
-                if req.strip() == "sklearn":
-                    requirements[i] = "scikit-learn"
+                requirements[i] = _artifact_utils.IMPORT_TO_PYPI.get(req, req)
         else:
             raise TypeError("`requirements` must be either str or list of str, not {}".format(type(requirements)))
 


### PR DESCRIPTION
## Examples
Top example reads [one of the repo's `requirements.txt`s](https://github.com/VertaAI/modeldb-client/blob/a5e042e/workflows/requirements.txt) and fills in version pins.

Bottom example takes module names and fills in version pins. Note:
- `>=999.13.10` is ignored and replaced with the environment's version, which is lower
- translation of `'sklearn'` to `'scikit-learn'`
- injections of `verta` and `cloudpickle`

![Screen Shot 2019-11-13 at 11 11 39 AM](https://user-images.githubusercontent.com/7754936/68795727-660e3900-0606-11ea-8264-ffa15bb1b686.png)

## Error Examples
![Screen Shot 2019-11-13 at 11 19 41 AM](https://user-images.githubusercontent.com/7754936/68796424-afab5380-0607-11ea-889b-194d4df0e45a.png)
![Screen Shot 2019-11-13 at 11 20 06 AM](https://user-images.githubusercontent.com/7754936/68796425-afab5380-0607-11ea-94aa-7e3bfdd9f3b0.png)

