### PR TITLE
VR-2868: Support logging class as model

### DIFF
--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -154,6 +154,15 @@ class TestLogModel:
         }
         assert model_api == json.loads(six.ensure_str(experiment_run.get_artifact('model_api.json').read()))
 
+    def test_model_class(self, experiment_run, model_for_deployment):
+        experiment_run.log_model(model_for_deployment['model'].__class__)
+
+        assert model_for_deployment['model'].__class__ == experiment_run.get_model()
+
+        retrieved_model_api = verta.utils.ModelAPI.from_file(experiment_run.get_artifact("model_api.json"))
+        assert retrieved_model_api.to_dict()['model_packaging']['type'] == "class"
+
+
 class TestLogRequirements:
     NONSPECIFIC_REQ = "verta>0.1.0"
     INVALID_REQ = "@==1.2.3"

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -222,6 +222,13 @@ def serialize_model(model):
         finally:
             reset_stream(model)  # reset cursor to beginning as a courtesy
 
+    # `model` is a class
+    if isinstance(model, six.class_types):
+        model_type = "class"
+        bytestream, method = ensure_bytestream(model)
+        return bytestream, method, model_type
+
+    # `model` is an instance
     for class_obj in model.__class__.__mro__:
         module_name = class_obj.__module__
         if not module_name:


### PR DESCRIPTION
## Examples
Predictions are successful, trust me.
The class was:
```python
class Model:
    def __init__(self, artifacts=None):
        print("We're in business")

    def predict(self, data):
        return [0]
```

`model.pkl` is a serialized class:
<img width="557" alt="Screen Shot 2019-11-25 at 1 11 23 PM" src="https://user-images.githubusercontent.com/7754936/69579221-eaf23e80-0f86-11ea-9b9e-ce582c1fdeb8.png">

This uses the [in-progress `ClassModelWrapper`](https://github.com/VertaAI/DeploymentService/pull/179/files), and the new model type `"class"`:
<img width="631" alt="Screen Shot 2019-11-25 at 1 23 38 PM" src="https://user-images.githubusercontent.com/7754936/69579223-eaf23e80-0f86-11ea-98d3-7c4eb77e985f.png">
