### PR TITLE
VR-2925: Unzip ZIPs in fetch_artifacts()

### DIFF
--- a/verta/tests/conftest.py
+++ b/verta/tests/conftest.py
@@ -196,6 +196,34 @@ def output_path():
 
 
 @pytest.fixture
+def dir_and_files(strs, tmp_path):
+    """
+    Creates nested directory of empty files.
+
+    Returns
+    -------
+    dirpath : str
+    filepaths : set of str
+
+    """
+    filepaths = {
+        os.path.join(strs[0], strs[1], strs[2]),
+        os.path.join(strs[0], strs[1], strs[3]),
+        os.path.join(strs[0], strs[2]),
+        os.path.join(strs[0], strs[4]),
+        os.path.join(strs[2]),
+        os.path.join(strs[5]),
+    }
+
+    for filepath in filepaths:
+        p = tmp_path / filepath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch()
+
+    return str(tmp_path), filepaths
+
+
+@pytest.fixture
 def client(host, port, email, dev_key):
     client = Client(host, port, email, dev_key, debug=True)
 

--- a/verta/tests/test_artifacts.py
+++ b/verta/tests/test_artifacts.py
@@ -54,24 +54,10 @@ class TestArtifacts:
             with open(artifact_filepath, 'rb') as artifact_file:
                 assert experiment_run.get_artifact(key).read() == artifact_file.read()
 
-    def test_upload_dir(self, experiment_run, strs, tmp_path):
+    def test_upload_dir(self, experiment_run, strs, dir_and_files):
+        dirpath, filepaths = dir_and_files
         key = strs[0]
-        filepaths = {
-            os.path.join(strs[1], strs[2], strs[3]),
-            os.path.join(strs[1], strs[2], strs[4]),
-            os.path.join(strs[1], strs[3]),
-            os.path.join(strs[1], strs[5]),
-            os.path.join(strs[3]),
-            os.path.join(strs[6]),
-        }
 
-        # create dir of empty files
-        for filepath in filepaths:
-            p = tmp_path / filepath
-            p.parent.mkdir(parents=True, exist_ok=True)
-            p.touch()
-
-        dirpath = str(tmp_path)
         experiment_run.log_artifact(key, dirpath)
 
         with zipfile.ZipFile(experiment_run.get_artifact(key), 'r') as zipf:


### PR DESCRIPTION
As an example, this unzips `banana.zip` into `cache/artifacts/$RUN_ID/banana/`.

I am confident this is fine because the Client has never allowed logging artifacts with keys that contain periods, i.e. a user in normal usage cannot log both `"banana"` and `"banana.zip"` (because they can only log one artifact with the key `"banana"`, and the `'.zip'` is appended internally by the Client), so there will not be a collision in the cache.