### PR TITLE
VR-2875: Convert common external datatypes into JSON

### DIFF
--- a/verta/tests/test_utils.py
+++ b/verta/tests/test_utils.py
@@ -1,0 +1,157 @@
+# pylint: disable=unidiomatic-typecheck
+
+import six
+
+import verta
+
+import pytest
+import utils
+
+
+class TestToBuiltin:
+    def test_string(self):
+        val = "banana"
+
+        assert verta._utils.to_builtin(val) == "banana"
+
+    def test_unicode(self):
+        val = u"banana"
+
+        assert verta._utils.to_builtin(val) == "banana"
+
+    def test_bytes(self):
+        val = b"banana"
+
+        assert verta._utils.to_builtin(val) == "banana"
+
+    def test_numpy_numbers(self):
+        np = pytest.importorskip("numpy")
+
+        ints = (
+            np.int8(), np.int16(), np.int32(), np.int64(),
+            np.uint8(), np.uint16(), np.uint32(), np.uint64(),
+        )
+        floats = (
+            np.float32(), np.float64(),
+        )
+
+        for val in ints:
+            assert type(verta._utils.to_builtin(val)) in six.integer_types
+
+        for val in floats:
+            assert type(verta._utils.to_builtin(val)) is float
+
+    def test_ndarray(self):
+        np = pytest.importorskip("numpy")
+
+        int_array = np.random.randint(-36, 36, size=(12, 24))
+        float_array = np.random.uniform(-36, 36, size=(12, 24))
+        str_array = np.array([list("banana"), list("coconut"), list("date")])
+
+        builtin_int_array = verta._utils.to_builtin(int_array)
+        assert type(builtin_int_array) is list
+        assert all(type(val) in six.integer_types
+                   for row in builtin_int_array
+                   for val in row)
+
+        builtin_float_array = verta._utils.to_builtin(float_array)
+        assert type(builtin_float_array) is list
+        assert all(type(val) is float
+                   for row in builtin_float_array
+                   for val in row)
+
+        builtin_str_array = verta._utils.to_builtin(str_array)
+        assert type(builtin_str_array) is list
+        assert all(type(val) is str
+                   for row in builtin_str_array
+                   for val in row)
+
+    def test_series(self):
+        pd = pytest.importorskip("pandas")
+
+        int_series = pd.Series([1, 2, 3])
+        float_series = pd.Series([1.0, 2.0, 3.0])
+        str_series = pd.Series(["one", "two", "thr"])
+
+        builtin_int_series = verta._utils.to_builtin(int_series)
+        assert type(builtin_int_series) is list
+        assert all(type(val) in six.integer_types for val in builtin_int_series)
+
+        builtin_float_series = verta._utils.to_builtin(float_series)
+        assert type(builtin_float_series) is list
+        assert all(type(val) is float for val in builtin_float_series)
+
+        builtin_str_series = verta._utils.to_builtin(str_series)
+        assert type(builtin_str_series) is list
+        assert all(type(val) is str for val in builtin_str_series)
+
+
+    def test_dataframe(self):
+        pd = pytest.importorskip("pandas")
+
+        int_frame = pd.DataFrame([[1, 1, 1],
+                                  [2, 2, 2],
+                                  [3, 3, 3]])
+        float_frame = pd.DataFrame([[1.0, 1.0, 1.0],
+                                    [2.0, 2.0, 2.0],
+                                    [3.0, 3.0, 3.0]])
+        str_frame = pd.DataFrame([["one", "one", "one"],
+                                  ["two", "two", "two"],
+                                  ["thr", "thr", "thr"]])
+
+        builtin_int_frame = verta._utils.to_builtin(int_frame)
+        assert type(builtin_int_frame) is list
+        assert all(type(val) in six.integer_types
+                   for row in builtin_int_frame
+                   for val in row)
+
+        builtin_float_frame = verta._utils.to_builtin(float_frame)
+        assert type(builtin_float_frame) is list
+        assert all(type(val) is float
+                   for row in builtin_float_frame
+                   for val in row)
+
+        builtin_str_frame = verta._utils.to_builtin(str_frame)
+        assert type(builtin_str_frame) is list
+        assert all(type(val) is str
+                   for row in builtin_str_frame
+                   for val in row)
+
+    def test_dict(self):
+        np = pytest.importorskip("numpy")
+
+        val = {
+            "banana": np.array([1, 2, 3]),
+            u"coconut": np.array([1.0, 2.0, 3.0]),
+            b"date": np.array(list("banana")),
+        }
+
+        builtin_val = verta._utils.to_builtin(val)
+
+        assert set(builtin_val.keys()) == {"banana", "coconut", "date"}
+        assert builtin_val['banana'] == [1, 2, 3]
+        assert builtin_val['coconut'] == [1.0, 2.0, 3.0]
+        assert builtin_val['date'] == list("banana")
+
+    def test_list(self):
+        np = pytest.importorskip("numpy")
+
+        int_list = list(np.array([1, 2, 3]))
+        float_list = list(np.array([1.0, 2.0, 3.0]))
+        str_list = list(np.array(list("banana")))
+
+        assert not any(type(val) in six.integer_types for val in int_list)
+        assert not any(type(val) is float for val in float_list)
+        assert not any(type(val) is str for val in str_list)
+
+        builtin_int_list = verta._utils.to_builtin(int_list)
+        assert type(builtin_int_list) is list
+        assert all(type(val) in six.integer_types for val in builtin_int_list)
+
+        builtin_float_list = verta._utils.to_builtin(float_list)
+        assert type(builtin_float_list) is list
+        assert all(type(val) is float for val in builtin_float_list)
+
+        builtin_str_list = verta._utils.to_builtin(str_list)
+        assert type(builtin_str_list) is list
+        assert all(type(val) is str for val in builtin_str_list)

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -280,6 +280,55 @@ def json_to_proto(response_json, response_cls):
                              ignore_unknown_fields=True)
 
 
+def to_builtin(obj):
+    """
+    Tries to coerce `obj` into a built-in type, for JSON serialization.
+
+    Parameters
+    ----------
+    obj
+
+    """
+    # jump through ludicrous hoops to avoid having hard dependencies in the Client
+    cls_ = obj.__class__
+    obj_class = getattr(cls_, '__name__', None)
+    obj_module = getattr(cls_, '__module__', None)
+
+    # NumPy scalars
+    if obj_module == "numpy" and ('int' in obj_class
+                                  or 'float' in obj_class
+                                  or 'str' in obj_class):
+        return obj.item()
+
+    # scientific library collections
+    if obj_class == "ndarray":
+        return obj.tolist()
+    if obj_class == "Series":
+        return obj.values.tolist()
+    if obj_class == "DataFrame":
+        return obj.values.tolist()
+    if obj_class == "Tensor" and obj_module == "torch":
+        return obj.numpy().tolist()
+
+    # strings
+    if isinstance(obj, six.string_types):  # prevent infinite loop with iter
+        return obj
+    if isinstance(obj, six.binary_type):
+        return six.ensure_str(obj)
+
+    # dicts and lists
+    if isinstance(obj, dict):
+        return {to_builtin(key): to_builtin(val) for key, val in six.viewitems(obj)}
+    try:
+        iter(obj)
+    except TypeError:
+        pass
+    else:
+        return [to_builtin(val) for val in obj]
+
+    return obj
+
+
 def python_to_val_proto(val, allow_collection=False):
     """
     Converts a Python variable into a `protobuf` `Value` `Message` object.

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -288,6 +288,11 @@ def to_builtin(obj):
     ----------
     obj
 
+    Returns
+    -------
+    object
+        A built-in equivalent of `obj`, or `obj` unchanged if it could not be handled by this function.
+
     """
     # jump through ludicrous hoops to avoid having hard dependencies in the Client
     cls_ = obj.__class__

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -295,9 +295,7 @@ def to_builtin(obj):
     obj_module = getattr(cls_, '__module__', None)
 
     # NumPy scalars
-    if obj_module == "numpy" and ('int' in obj_class
-                                  or 'float' in obj_class
-                                  or 'str' in obj_class):
+    if obj_module == "numpy" and obj_class.startswith(('int', 'uint', 'float', 'str')):
         return obj.item()
 
     # scientific library collections

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -150,6 +150,8 @@ class DeployedModel:
         if 'Access-token' not in self._session.headers or self._prediction_url is None:
             self._set_token_and_url()
 
+        x = _utils.to_builtin(x)
+
         if compress:
             # create gzip
             gzstream = six.BytesIO()


### PR DESCRIPTION
I chose to do the type/class checks by string comparison because the method used [in Model Service](https://github.com/VertaAI/DeploymentService/blob/5641633/model_service/app/api/predict_resource.py#L20) (attempting imports of the library, since the Client tries to not enforce hard dependencies) would introduce many, many more lines of code and in my opinion add complexity.

String comparisons can be prone to typos, but that's why I have tests.

## Examples
![Screen Shot 2019-12-03 at 2 39 48 PM](https://user-images.githubusercontent.com/7754936/70096027-f83ca800-15da-11ea-89db-50157e5a0fa5.png)
![Screen Shot 2019-12-03 at 2 40 00 PM](https://user-images.githubusercontent.com/7754936/70096028-f83ca800-15da-11ea-9466-9b336b21af3b.png)
![Screen Shot 2019-12-03 at 2 44 18 PM](https://user-images.githubusercontent.com/7754936/70096219-6aad8800-15db-11ea-827d-c07095ed3fb7.png)
