### PR TITLE
Include internal copy of six v1.12.0

### DIFF
--- a/verta/setup.py
+++ b/verta/setup.py
@@ -31,6 +31,5 @@ setup(
         "pathlib2>=2.2",
         "protobuf>=3.8",
         "requests>=2.21, <3.0",
-        "six>=1.12",
     ],
 )

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import six
-import six.moves.cPickle as pickle
+import _six
+import _six.moves.cPickle as pickle
 
 import csv
 import importlib
@@ -62,7 +62,7 @@ def get_file_ext(file):
         If the filepath lacks an extension.
 
     """
-    if isinstance(file, six.string_types):
+    if isinstance(file, _six.string_types):
         filepath = file
     elif hasattr(file, 'read') and hasattr(file, 'name'):  # `open()` object
         filepath = file.name
@@ -73,7 +73,7 @@ def get_file_ext(file):
     try:
         _, extension = filename.split(os.extsep, 1)
     except ValueError:
-        six.raise_from(ValueError("no extension found in \"{}\"".format(filepath)),
+        _six.raise_from(ValueError("no extension found in \"{}\"".format(filepath)),
                        None)
     else:
         return extension
@@ -159,12 +159,12 @@ def ensure_bytestream(obj):
         reset_stream(obj)  # reset cursor to beginning as a courtesy
         if not len(contents):
             raise ValueError("object contains no data")
-        bytestring = six.ensure_binary(contents)
-        bytestream = six.BytesIO(bytestring)
+        bytestring = _six.ensure_binary(contents)
+        bytestream = _six.BytesIO(bytestring)
         bytestream.seek(0)
         return bytestream, None
     else:  # `obj` is not file-like
-        bytestream = six.BytesIO()
+        bytestream = _six.BytesIO()
 
         try:
             cloudpickle.dump(obj, bytestream)
@@ -186,7 +186,7 @@ def ensure_bytestream(obj):
         try:
             pickle.dump(obj, bytestream)
         except pickle.PicklingError:  # can't be handled by pickle
-            six.raise_from(pickle.PicklingError("unable to serialize artifact"), None)
+            _six.raise_from(pickle.PicklingError("unable to serialize artifact"), None)
         else:
             bytestream.seek(0)
             return bytestream, "pickle"
@@ -223,7 +223,7 @@ def serialize_model(model):
             reset_stream(model)  # reset cursor to beginning as a courtesy
 
     # `model` is a class
-    if isinstance(model, six.class_types):
+    if isinstance(model, _six.class_types):
         model_type = "class"
         bytestream, method = ensure_bytestream(model)
         return bytestream, method, model_type
@@ -293,7 +293,7 @@ def deserialize_model(bytestring):
             pass
 
     # try deserializing with cloudpickle
-    bytestream = six.BytesIO(bytestring)
+    bytestream = _six.BytesIO(bytestring)
     try:
         return cloudpickle.load(bytestream)
     except:  # not a pickled object
@@ -350,11 +350,11 @@ def process_requirements(requirements):
             try:
                 mod = importlib.import_module(mod_name)
             except ImportError:
-                six.raise_from(error, None)
+                _six.raise_from(error, None)
             try:
                 ver = mod.__version__
             except AttributeError:
-                six.raise_from(error, None)
+                _six.raise_from(error, None)
 
             requirements[i] = req + "==" + ver
 

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from . import _six
-from ._six.moves import cPickle as pickle
+from ._six.moves import cPickle as pickle  # pylint: disable=import-error, no-name-in-module
 
 import csv
 import importlib

--- a/verta/verta/_artifact_utils.py
+++ b/verta/verta/_artifact_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import _six
-import _six.moves.cPickle as pickle
+from . import _six
+from ._six.moves import cPickle as pickle
 
 import csv
 import importlib

--- a/verta/verta/_dataset.py
+++ b/verta/verta/_dataset.py
@@ -1,4 +1,4 @@
-import six
+import _six
 
 import hashlib
 import os
@@ -116,7 +116,7 @@ class Dataset(object):
     def _create(conn, dataset_name, dataset_type, desc=None, tags=None, attrs=None):
         if attrs is not None:
             attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
-                     for key, value in six.viewitems(attrs)]
+                     for key, value in _six.viewitems(attrs)]
 
         Message = _DatasetService.CreateDataset
         msg = Message(name=dataset_name, dataset_type=dataset_type,
@@ -526,7 +526,7 @@ class DatasetVersion(object):
                 version=None):
         if attrs is not None:
             attrs = [_CommonService.KeyValue(key=key, value=_utils.python_to_val_proto(value, allow_collection=True))
-                     for key, value in six.viewitems(attrs)]
+                     for key, value in _six.viewitems(attrs)]
 
         if dataset_type == _DatasetService.DatasetTypeEnum.PATH:
             msg = PathDatasetVersion.make_create_message(
@@ -727,7 +727,7 @@ class S3DatasetVersionInfo(PathDatasetVersionInfo):
 
     def get_dataset_part_infos(self):
         if boto3 is None:  # Boto 3 not installed
-            six.raise_from(ImportError("Boto 3 is not installed; try `pip install boto3`"), None)
+            _six.raise_from(ImportError("Boto 3 is not installed; try `pip install boto3`"), None)
 
         conn = boto3.client('s3')
         dataset_part_infos = []
@@ -832,7 +832,7 @@ class AtlasHiveDatasetVersionInfo(QueryDatasetVersionInfo):
         attributes['created_time'] = table_obj['createTime']
         attributes['update_time'] = table_obj['updateTime']
         attributes['load_queries'] = AtlasHiveDatasetVersionInfo.get_inbound_queries(table_obj)
-        # for key, value in six.viewitems(attributes):
+        # for key, value in _six.viewitems(attributes):
             # attribute_keyvals.append(_CommonService.KeyValue(key=key,
             #                                                  value=_utils.python_to_val_proto(value, allow_collection=True)))
         # return attribute_keyvals
@@ -875,7 +875,7 @@ class BigQueryDatasetVersionInfo(QueryDatasetVersionInfo):
     @staticmethod
     def get_bq_job(job_id, location):
         if bigquery is None:  # BigQuery not installed
-            six.raise_from(ImportError("BigQuery is not installed;"
+            _six.raise_from(ImportError("BigQuery is not installed;"
                                        " try `pip install google-cloud-bigquery`"),
                            None)
 

--- a/verta/verta/_dataset.py
+++ b/verta/verta/_dataset.py
@@ -1,4 +1,4 @@
-import _six
+from . import _six
 
 import hashlib
 import os

--- a/verta/verta/_six.py
+++ b/verta/verta/_six.py
@@ -1,0 +1,942 @@
+# Copyright (c) 2010-2018 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.12.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """Coerce **s** to six.binary_type.
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    elif isinstance(s, binary_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to `str`.
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """Coerce *s* to six.text_type.
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, text_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/verta/verta/_six.py
+++ b/verta/verta/_six.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# pylint: disable-all
+
 """Utilities for writing code that runs on Python 2 and 3"""
 
 from __future__ import absolute_import

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import _six
-from _six.moves.urllib.parse import urljoin
+from . import _six
+from ._six.moves.urllib.parse import urljoin
 
 import datetime
 import inspect

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from . import _six
-from ._six.moves.urllib.parse import urljoin
+from ._six.moves.urllib.parse import urljoin  # pylint: disable=import-error, no-name-in-module
 
 import datetime
 import inspect

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import six
-from six.moves.urllib.parse import urljoin
+import _six
+from _six.moves.urllib.parse import urljoin
 
 import datetime
 import inspect
@@ -144,7 +144,7 @@ def make_request(method, url, conn, **kwargs):
         # fabricate response
         response = requests.Response()
         response.status_code = 200  # success
-        response._content = six.ensure_binary("{}")  # empty contents
+        response._content = _six.ensure_binary("{}")  # empty contents
         return response
 
 
@@ -170,7 +170,7 @@ def raise_for_http_error(response):
             reason = response.json()['message']
         except (ValueError,  # not JSON response
                 KeyError):  # no 'message' from back end
-            six.raise_from(e, None)  # use default reason
+            _six.raise_from(e, None)  # use default reason
         else:
             # replicate https://github.com/psf/requests/blob/428f7a/requests/models.py#L954
             if 400 <= response.status_code < 500:
@@ -180,7 +180,7 @@ def raise_for_http_error(response):
             else:  # should be impossible here, but sure okay
                 cause = "Unexpected"
             message = "{} {} Error: {} for url: {}".format(response.status_code, cause, reason, response.url)
-            six.raise_from(requests.HTTPError(message, response=response), None)
+            _six.raise_from(requests.HTTPError(message, response=response), None)
 
 
 def is_hidden(path):  # to avoid "./".startswith('.')
@@ -205,10 +205,10 @@ def find_filepaths(paths, extensions=None, include_hidden=False, include_venv=Fa
         Whether to include Python virtual environment directories.
 
     """
-    if isinstance(paths, six.string_types):
+    if isinstance(paths, _six.string_types):
         paths = [paths]
 
-    if isinstance(extensions, six.string_types):
+    if isinstance(extensions, _six.string_types):
         extensions = [extensions]
     if extensions is not None:
         # prepend period to file extensions where missing
@@ -304,7 +304,7 @@ def python_to_val_proto(val, allow_collection=False):
         return Value(bool_value=val)
     elif isinstance(val, numbers.Real):
         return Value(number_value=val)
-    elif isinstance(val, six.string_types):
+    elif isinstance(val, _six.string_types):
         return Value(string_value=val)
     elif isinstance(val, (list, dict)):
         if allow_collection:
@@ -313,7 +313,7 @@ def python_to_val_proto(val, allow_collection=False):
                 list_value.extend(val)
                 return Value(list_value=list_value)
             else:  # isinstance(val, dict)
-                if all([isinstance(key, six.string_types) for key in val.keys()]):
+                if all([isinstance(key, _six.string_types) for key in val.keys()]):
                     struct_value = Struct()
                     struct_value.update(val)
                     return Value(struct_value=struct_value)
@@ -546,19 +546,19 @@ def ensure_timestamp(timestamp):
         `timestamp` with millisecond resolution (13 integer digits).
 
     """
-    if isinstance(timestamp, six.string_types):
+    if isinstance(timestamp, _six.string_types):
         try:  # attempt with pandas, which can parse many time string formats
             return timestamp_to_ms(pd.Timestamp(timestamp).timestamp())
         except NameError:  # pandas not installed
-            six.raise_from(ValueError("pandas must be installed to parse datetime strings"),
+            _six.raise_from(ValueError("pandas must be installed to parse datetime strings"),
                            None)
         except ValueError:  # can't be handled by pandas
-            six.raise_from(ValueError("unable to parse datetime string \"{}\"".format(timestamp)),
+            _six.raise_from(ValueError("unable to parse datetime string \"{}\"".format(timestamp)),
                            None)
     elif isinstance(timestamp, numbers.Real):
         return timestamp_to_ms(timestamp)
     elif isinstance(timestamp, datetime.datetime):
-        if six.PY2:
+        if _six.PY2:
             # replicate https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp
             seconds = (timestamp - datetime.datetime(1970, 1, 1, tzinfo=UTC())).total_seconds()
         else:  # Python 3
@@ -661,7 +661,7 @@ def save_notebook(timeout=5):
         with open(notebook_path, 'r') as f:
             contents = f.read()
         if contents:
-            return six.StringIO(contents)
+            return _six.StringIO(contents)
         time.sleep(0.01)
     else:
         raise OSError("unable to read saved notebook")
@@ -734,7 +734,7 @@ def get_script_filepath():
 
 def get_git_commit_hash():
     try:
-        return six.ensure_str(
+        return _six.ensure_str(
             subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"])
         ).strip()
     except:
@@ -745,7 +745,7 @@ def get_git_commit_hash():
 def get_git_commit_dirtiness(commit_hash=None):
     if commit_hash is not None:
         try:  # compare `commit_hash` to the working tree and index
-            diffs = six.ensure_str(
+            diffs = _six.ensure_str(
                 subprocess.check_output(["git", "diff-index", commit_hash])
             ).splitlines()
         except:
@@ -754,7 +754,7 @@ def get_git_commit_dirtiness(commit_hash=None):
             return len(diffs) > 0
     else:
         try:
-            diff_paths = six.ensure_str(
+            diff_paths = _six.ensure_str(
                 subprocess.check_output(["git", "status", "--porcelain"])
             ).splitlines()
         except:
@@ -766,7 +766,7 @@ def get_git_commit_dirtiness(commit_hash=None):
 
 def get_git_remote_url():
     try:
-        return six.ensure_str(
+        return _six.ensure_str(
             subprocess.check_output(["git", "ls-remote", "--get-url"])
         ).strip()
     except:
@@ -776,7 +776,7 @@ def get_git_remote_url():
 
 def get_git_branch_name():
     try:
-        return six.ensure_str(
+        return _six.ensure_str(
             subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
         ).strip()
     except:
@@ -786,7 +786,7 @@ def get_git_branch_name():
 
 def get_git_repo_root_dir():
     try:
-        dirpath = six.ensure_str(
+        dirpath = _six.ensure_str(
             subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
         ).strip()
     except:
@@ -808,4 +808,4 @@ def get_git_repo_root_dir():
 #         Names of packages and their pinned version numbers in the current Python environment.
 
 #     """
-#     return six.ensure_str(subprocess.check_output(["pip", "freeze"])).splitlines()
+#     return _six.ensure_str(subprocess.check_output(["pip", "freeze"])).splitlines()

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import _six
-import _six.moves.cPickle as pickle
-from _six.moves.urllib.parse import urlparse
+from . import _six
+from ._six.moves import cPickle as pickle
+from ._six.moves.urllib.parse import urlparse
 
 import ast
 import copy

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from . import _six
-from ._six.moves import cPickle as pickle
-from ._six.moves.urllib.parse import urlparse
+from ._six.moves import cPickle as pickle  # pylint: disable=import-error, no-name-in-module
+from ._six.moves.urllib.parse import urlparse  # pylint: disable=import-error, no-name-in-module
 
 import ast
 import copy

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import six
-from six.moves.urllib.parse import urljoin, urlparse
+import _six
+from _six.moves.urllib.parse import urljoin, urlparse
 
 import json
 import gzip
@@ -72,11 +72,11 @@ class DeployedModel:
             try:
                 self._session.headers.update({_GRPC_PREFIX+'email': os.environ['VERTA_EMAIL']})
             except KeyError:
-                six.raise_from(EnvironmentError("${} not found in environment".format('VERTA_EMAIL')), None)
+                _six.raise_from(EnvironmentError("${} not found in environment".format('VERTA_EMAIL')), None)
             try:
                 self._session.headers.update({_GRPC_PREFIX+'developer_key': os.environ['VERTA_DEV_KEY']})
             except KeyError:
-                six.raise_from(EnvironmentError("${} not found in environment".format('VERTA_DEV_KEY')), None)
+                _six.raise_from(EnvironmentError("${} not found in environment".format('VERTA_DEV_KEY')), None)
 
         back_end_url = urlparse(host)
         self._scheme = back_end_url.scheme or "https"
@@ -152,9 +152,9 @@ class DeployedModel:
 
         if compress:
             # create gzip
-            gzstream = six.BytesIO()
+            gzstream = _six.BytesIO()
             with gzip.GzipFile(fileobj=gzstream, mode='wb') as gzf:
-                gzf.write(six.ensure_binary(json.dumps(x)))
+                gzf.write(_six.ensure_binary(json.dumps(x)))
             gzstream.seek(0)
 
             return self._session.post(

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import _six
-from _six.moves.urllib.parse import urljoin, urlparse
+from . import _six
+from ._six.moves.urllib.parse import urljoin, urlparse
 
 import json
 import gzip

--- a/verta/verta/deployment.py
+++ b/verta/verta/deployment.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from . import _six
-from ._six.moves.urllib.parse import urljoin, urlparse
+from ._six.moves.urllib.parse import urljoin, urlparse  # pylint: disable=import-error, no-name-in-module
 
 import json
 import gzip

--- a/verta/verta/utils.py
+++ b/verta/verta/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import _six
-import _six.moves.cPickle as pickle
+from . import _six
+from ._six.moves import cPickle as pickle
 
 import collections
 import json

--- a/verta/verta/utils.py
+++ b/verta/verta/utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from . import _six
-from ._six.moves import cPickle as pickle
 
 import collections
 import json

--- a/verta/verta/utils.py
+++ b/verta/verta/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import six
-import six.moves.cPickle as pickle
+import _six
+import _six.moves.cPickle as pickle
 
 import collections
 import json
@@ -44,7 +44,7 @@ class ModelAPI(object):
             api.update({
                 'output': ModelAPI._data_to_api(y),
             })
-        self._buffer = six.StringIO(json.dumps(api))
+        self._buffer = _six.StringIO(json.dumps(api))
 
     def __str__(self):
         ptr_pos = self.tell()  # save current pointer position
@@ -58,7 +58,7 @@ class ModelAPI(object):
             raise ValueError("pointer must be reset before setting an item; please use seek(0)")
         api_dict = json.loads(self.read())
         api_dict[key] = value
-        self._buffer = six.StringIO(json.dumps(api_dict))
+        self._buffer = _six.StringIO(json.dumps(api_dict))
 
     def __contains__(self, key):
         return key in self.to_dict()
@@ -86,7 +86,7 @@ class ModelAPI(object):
         try:
             first_datum = data[0]
         except:
-            six.raise_from(TypeError("arguments to ModelAPI() must be lists of data"), None)
+            _six.raise_from(TypeError("arguments to ModelAPI() must be lists of data"), None)
         return ModelAPI._single_data_to_api(first_datum, name)
 
     @staticmethod
@@ -121,19 +121,19 @@ class ModelAPI(object):
         elif isinstance(data, numbers.Real):
             return {'type': "VertaFloat",
                     'name': str(name)}
-        elif isinstance(data, six.string_types):
+        elif isinstance(data, _six.string_types):
             return {'type': "VertaString",
                     'name': str(name)}
         elif isinstance(data, collections.Mapping):
             return {'type': "VertaJson",
                     'name': str(name),
                     'value': [ModelAPI._single_data_to_api(value, str(name))
-                              for name, value in sorted(six.iteritems(data), key=lambda item: item[0])]}
+                              for name, value in sorted(_six.iteritems(data), key=lambda item: item[0])]}
         else:
             try:
                 iter(data)
             except TypeError:
-                six.raise_from(TypeError("uninterpretable type {}".format(type(data))), None)
+                _six.raise_from(TypeError("uninterpretable type {}".format(type(data))), None)
             else:
                 return {'type': "VertaList",
                         'name': name,
@@ -154,11 +154,11 @@ class ModelAPI(object):
         :class:`ModelAPI`
 
         """
-        if isinstance(f, six.string_types):
+        if isinstance(f, _six.string_types):
             f = open(f, 'r')
 
         model_api = ModelAPI([None], [None])  # create a dummy instance
-        model_api._buffer = six.StringIO(six.ensure_str(f.read()))
+        model_api._buffer = _six.StringIO(_six.ensure_str(f.read()))
         return model_api
 
     def read(self, size=None):


### PR DESCRIPTION
[`pytest`s succeed](https://jenkins.dev.verta.ai/job/client/job/test-python-versions/132/console). Note that `six` is still installed because `pathlib2` and `protobuf` (`six>=1.9`) depend on it.

Also our test suite itself still uses it, but it's purged from the Client library source:
<img width="733" alt="Screen Shot 2019-12-04 at 2 06 09 PM" src="https://user-images.githubusercontent.com/7754936/70185766-46b37a80-169f-11ea-9cf6-50fbf54a9762.png">

