### PR TITLE
VR-3036: Check for presence of error msg

### DIFF
--- a/verta/tests/test_deployment.py
+++ b/verta/tests/test_deployment.py
@@ -682,7 +682,9 @@ class TestDeploy:
         try:
             with pytest.raises(RuntimeError) as excinfo:
                 experiment_run.deploy(wait=True)
-            assert str(excinfo.value).strip().startswith("model deployment is failing;")
+            err_msg = str(excinfo.value).strip()
+            assert err_msg.startswith("model deployment is failing;")
+            assert "no error message available" not in err_msg
         finally:
             conn = experiment_run._conn
             requests.delete(


### PR DESCRIPTION
Two weeks ago, I introduced [a bug](https://github.com/VertaAI/modeldb-client/pull/320) where error messages from deployment weren't being propagated. It wasn't caught by tests because this test didn't check the content of the error message; now it does.