### PR TITLE
VR-3016: fix _log_modules() to include fake venvs

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -4,6 +4,7 @@ from . import _six
 from ._six.moves.urllib.parse import urljoin  # pylint: disable=import-error, no-name-in-module
 
 import datetime
+import glob
 import inspect
 import json
 import numbers
@@ -231,8 +232,8 @@ def find_filepaths(paths, extensions=None, include_hidden=False, include_venv=Fa
                     # skip hidden files
                     filenames[:] = [filename for filename in filenames if not is_hidden(filename)]
                 if not include_venv:
-                    exec_path = os.path.join(parent_dir, "{}", "bin", "python")
-                    dirnames[:] = [dirname for dirname in dirnames if not os.path.lexists(exec_path.format(dirname))]
+                    exec_path_glob = os.path.join(parent_dir, "{}", "bin", "python*")
+                    dirnames[:] = [dirname for dirname in dirnames if not glob.glob(exec_path_glob.format(dirname))]
                 for filename in filenames:
                     if extensions is None or os.path.splitext(filename)[1] in extensions:
                         filepaths.add(os.path.join(parent_dir, filename))

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -206,6 +206,10 @@ def find_filepaths(paths, extensions=None, include_hidden=False, include_venv=Fa
     include_venv : bool, default False
         Whether to include Python virtual environment directories.
 
+    Returns
+    -------
+    filepaths : set
+
     """
     if isinstance(paths, _six.string_types):
         paths = [paths]

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -3217,16 +3217,17 @@ class ExperimentRun(_ModelDBEntity):
         # get paths to files within
         if paths is None:
             # Python files within filtered sys.path dirs
-            local_filepaths = _utils.find_filepaths(
-                local_sys_paths, extensions=['py', 'pyc', 'pyo'],
-                include_hidden=True, include_venv=False,
-            )
+            paths = local_sys_paths
+            extensions = ['py', 'pyc', 'pyo']
         else:
             # all user-specified files
-            local_filepaths = _utils.find_filepaths(
-                paths,
-                include_hidden=True, include_venv=False,
-            )
+            paths = paths
+            extensions = None
+        local_filepaths = _utils.find_filepaths(
+            paths, extensions=extensions,
+            include_hidden=True,
+            include_venv=False,  # ignore virtual environments nested within
+        )
 
         # obtain deepest common directory
         #     This directory on the local system will be mirrored in `_CUSTOM_MODULES_DIR` in

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -3203,7 +3203,7 @@ class ExperimentRun(_ModelDBEntity):
             Roughly checks for:
                 /
                 |_ lib/
-                |   |_ python*/ <- `path`, directory with Python packages
+                |   |_ python*/ <- directory with Python packages, containing `path`
                 |
                 |_ bin/
                     |_ python*  <- Python executable

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -3187,8 +3187,10 @@ class ExperimentRun(_ModelDBEntity):
 
         # collect local sys paths
         local_sys_paths = copy.copy(sys.path)
-        ## remove empty strings
-        local_sys_paths = list(filter(None, local_sys_paths))
+        ## replace empty first element with cwd
+        ##     https://docs.python.org/3/library/sys.html#sys.path
+        if local_sys_paths[0] == "":
+            local_sys_paths[0] = os.getcwd()
         ## convert to absolute paths
         local_sys_paths = list(map(os.path.abspath, local_sys_paths))
         ## remove paths that don't exist

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -40,6 +40,7 @@ from . import deployment
 
 
 # for ExperimentRun._log_modules()
+_CUSTOM_MODULES_DIR = "/app/custom_modules/"  # location in DeploymentService model container
 PY_DIR_REGEX = re.compile(r"/lib/python\d\.\d")
 PY_ZIP_REGEX = re.compile(r"/lib/python\d\d\.zip")
 IPYTHON_REGEX = re.compile(r"/\.ipython")
@@ -3195,8 +3196,6 @@ class ExperimentRun(_ModelDBEntity):
         if isinstance(paths, _six.string_types):
             paths = [paths]
 
-        CUSTOM_MODULES_DIR = "/app/custom_modules/"  # location in DeploymentService model container
-
         # convert into absolute paths
         paths = map(os.path.abspath, paths)
         # add trailing separator to directories
@@ -3222,7 +3221,7 @@ class ExperimentRun(_ModelDBEntity):
         # strip common directory
         search_paths = list(map(lambda path: os.path.relpath(path, common_dir), search_paths))
         # append to Deployment's custom modules directory
-        search_paths = list(map(lambda path: os.path.join(CUSTOM_MODULES_DIR, path), search_paths))
+        search_paths = list(map(lambda path: os.path.join(_CUSTOM_MODULES_DIR, path), search_paths))
         if self._conf.debug:
             print("[DEBUG] deployment search paths are:")
             pprint.pprint(search_paths)
@@ -3233,7 +3232,7 @@ class ExperimentRun(_ModelDBEntity):
                 zipf.write(filepath, os.path.relpath(filepath, common_dir))
 
             # add verta config file for sys.path and chdir
-            working_dir = os.path.join(CUSTOM_MODULES_DIR, os.path.relpath(curr_dir, common_dir))
+            working_dir = os.path.join(_CUSTOM_MODULES_DIR, os.path.relpath(curr_dir, common_dir))
             zipf.writestr(
                 "_verta_config.py",
                 _six.ensure_binary('\n'.join([

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -3203,7 +3203,7 @@ class ExperimentRun(_ModelDBEntity):
             Roughly checks for:
                 /
                 |_ lib/
-                |   |_ python*/ <- directory with packages, in sys.path
+                |   |_ python*/ <- `path`, directory with Python packages
                 |
                 |_ bin/
                     |_ python*  <- Python executable
@@ -3216,7 +3216,7 @@ class ExperimentRun(_ModelDBEntity):
 
         # get paths to files within
         if paths is None:
-            # Python files within sys.path dirs
+            # Python files within filtered sys.path dirs
             local_filepaths = _utils.find_filepaths(
                 local_sys_paths, extensions=['py', 'pyc', 'pyo'],
                 include_hidden=True, include_venv=False,


### PR DESCRIPTION
Filtering out [real] virtual environment files involves two steps:

1. remove `possible-venv/lib/python*/site-packages` from `sys.path`'s elements if `possible-venv/bin/python*` exists
1. while walking through directories for files to upload, ignore inner `possible-venv/` we might find if `possible-venv/bin/python*` exists