### PR TITLE
Fix Client bug from protos movement

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -369,12 +369,12 @@ def python_to_val_proto(val, allow_collection=False):
         if allow_collection:
             if isinstance(val, list):
                 list_value = ListValue()
-                list_value.extend(val)
+                list_value.extend(val)  # pylint: disable=no-member
                 return Value(list_value=list_value)
             else:  # isinstance(val, dict)
                 if all([isinstance(key, _six.string_types) for key in val.keys()]):
                     struct_value = Struct()
-                    struct_value.update(val)
+                    struct_value.update(val)  # pylint: disable=no-member
                     return Value(struct_value=struct_value)
                 else:  # protobuf's fault
                     raise TypeError("struct keys must be strings; consider using log_artifact() instead")

--- a/verta/verta/client.py
+++ b/verta/verta/client.py
@@ -28,6 +28,7 @@ try:
 except ImportError:  # Pillow not installed
     PIL = None
 
+from ._protos.public.common import CommonService_pb2 as _CommonCommonService
 from ._protos.public.modeldb import CommonService_pb2 as _CommonService
 from ._protos.public.modeldb import ProjectService_pb2 as _ProjectService
 from ._protos.public.modeldb import ExperimentService_pb2 as _ExperimentService
@@ -823,7 +824,10 @@ class _ModelDBEntity(object):
             except OSError as e:
                 print("{}; skipping".format(e))
             else:
-                msg.code_version.git_snapshot.is_dirty = _CommonService.TernaryEnum.TRUE if is_dirty else _CommonService.TernaryEnum.FALSE
+                if is_dirty:
+                    msg.code_version.git_snapshot.is_dirty = _CommonCommonService.TernaryEnum.TRUE
+                else:
+                    msg.code_version.git_snapshot.is_dirty = _CommonCommonService.TernaryEnum.FALSE
         else:  # log code as Artifact
             # write ZIP archive
             zipstream = _six.BytesIO()
@@ -917,8 +921,8 @@ class _ModelDBEntity(object):
                 git_snapshot['repo_url'] = git_snapshot_msg.repo
             if git_snapshot_msg.hash:
                 git_snapshot['commit_hash'] = git_snapshot_msg.hash
-                if git_snapshot_msg.is_dirty != _CommonService.TernaryEnum.UNKNOWN:
-                    git_snapshot['is_dirty'] = git_snapshot_msg.is_dirty == _CommonService.TernaryEnum.TRUE
+                if git_snapshot_msg.is_dirty != _CommonCommonService.TernaryEnum.UNKNOWN:
+                    git_snapshot['is_dirty'] = git_snapshot_msg.is_dirty == _CommonCommonService.TernaryEnum.TRUE
             return git_snapshot
         elif which_code == 'code_archive':
             # download artifact from artifact store


### PR DESCRIPTION
`TernaryEnum` was moved from `public::modeldb::CommonService` to `public::common::CommonService`.

My linter caught this, but I neglected to check it before #332 because I thought my tests would catch any problems.
My tests did _not_ catch this because `TernaryEnum` is only used when logging a Git code version on a dirty commit, which is not covered in my tests because I hadn't figured a way to manipulate the Git working tree in the test containers.