### PR TITLE
VR-3161: Implement hook for PyTorch

### DIFF
--- a/verta/docs/reference/api/integrations.rst
+++ b/verta/docs/reference/api/integrations.rst
@@ -7,5 +7,8 @@ Integrations
 .. automodule:: verta.integrations.tensorflow
     :members:
 
+.. automodule:: verta.integrations.torch
+    :members:
+
 .. automodule:: verta.integrations.xgboost
     :members:

--- a/verta/verta/integrations/torch/__init__.py
+++ b/verta/verta/integrations/torch/__init__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from ... import _six
+
+import torch
+
+from ... import _utils
+
+
+def verta_hook(run):
+    """
+    PyTorch module hook that automates logging to Verta during training.
+
+    .. versionadded:: 0.13.20
+
+    Parameters
+    ----------
+    run : :class:`~verta.client.ExperimentRun`
+        Experiment Run tracking this model.
+
+    Examples
+    --------
+    >>> from verta.integrations.torch import verta_hook
+    >>> run = client.set_experiment_run()
+    >>> model.register_forward_hook(verta_hook(run))
+    >>> output = model(X_train)
+
+    """
+    def hook(module, input, output):
+        for i, layer in enumerate(module.children()):
+            try:
+                run.log_hyperparameter("layer_{}_name".format(i), layer.__class__.__name__)
+            except:
+                pass  # don't halt execution
+
+            layer_params = {
+                "layer_{}_{}".format(i, attr): getattr(layer, attr)
+                for attr in layer.__dict__
+                if not attr.startswith('_')
+                and attr != "training"
+            }
+            try:
+                run.log_hyperparameters(layer_params)
+            except:
+                pass  # don't halt execution
+
+            print(output)
+    return hook

--- a/verta/verta/integrations/torch/__init__.py
+++ b/verta/verta/integrations/torch/__init__.py
@@ -11,6 +11,8 @@ def verta_hook(run):
     """
     PyTorch module hook that automates logging to Verta during training.
 
+    This hook logs details about the network's topology.
+
     .. versionadded:: 0.13.20
 
     Parameters
@@ -43,6 +45,4 @@ def verta_hook(run):
                 run.log_hyperparameters(layer_params)
             except:
                 pass  # don't halt execution
-
-            print(output)
     return hook

--- a/verta/verta/integrations/torch/__init__.py
+++ b/verta/verta/integrations/torch/__init__.py
@@ -11,7 +11,7 @@ def verta_hook(run):
     """
     PyTorch module hook that automates logging to Verta during training.
 
-    This hook logs details about the network's topology.
+    This hook logs details about the network topology.
 
     .. versionadded:: 0.13.20
 


### PR DESCRIPTION
This hook only logs information about the network's submodules, for example:
```python
{
    'layer_0_name': 'Linear',
    'layer_0_in_features': 3,
    'layer_0_out_features': 512,
    'layer_1_name': 'Dropout',
    'layer_1_p': 0.2,
    'layer_1_inplace': False,
    'layer_2_name': 'Linear',
    'layer_2_in_features': 512,
    'layer_2_out_features': 10,
}
```
Unfortunately because of how PyTorch works, `loss` is not exposed to hooks. Weights and gradients are, though, if we ever want to do something with those.