### PR TITLE
Try to coerce values to built-ins for logging non-artifacts

### DIFF
--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -339,13 +339,13 @@ def to_builtin(obj):
     return obj
 
 
-def python_to_val_proto(val, allow_collection=False):
+def python_to_val_proto(raw_val, allow_collection=False):
     """
     Converts a Python variable into a `protobuf` `Value` `Message` object.
 
     Parameters
     ----------
-    val : one of {None, bool, float, int, str, list, dict}
+    raw_val
         Python variable.
     allow_collection : bool, default False
         Whether to allow ``list``s and ``dict``s as `val`. This flag exists because some callers
@@ -358,7 +358,7 @@ def python_to_val_proto(val, allow_collection=False):
 
     """
     # TODO: check `allow_collection` before `to_builtin()` to avoid unnecessary processing
-    val = to_builtin(val)
+    val = to_builtin(raw_val)
 
     if val is None:
         return Value(null_value=NULL_VALUE)
@@ -382,9 +382,9 @@ def python_to_val_proto(val, allow_collection=False):
                 else:  # protobuf's fault
                     raise TypeError("struct keys must be strings; consider using log_artifact() instead")
         else:
-            raise TypeError("unsupported type {}; consider using log_attribute() instead".format(type(val)))
+            raise TypeError("unsupported type {}; consider using log_attribute() instead".format(type(raw_val)))
     else:
-        raise TypeError("unsupported type {}; consider using log_artifact() instead".format(type(val)))
+        raise TypeError("unsupported type {}; consider using log_artifact() instead".format(type(raw_val)))
 
 
 def val_proto_to_python(msg):

--- a/verta/verta/_utils.py
+++ b/verta/verta/_utils.py
@@ -318,7 +318,7 @@ def to_builtin(obj):
     if obj_class == "DataFrame":
         return obj.values.tolist()
     if obj_class == "Tensor" and obj_module == "torch":
-        return obj.numpy().tolist()
+        return obj.detach().numpy().tolist()
 
     # strings
     if isinstance(obj, _six.string_types):  # prevent infinite loop with iter
@@ -357,6 +357,9 @@ def python_to_val_proto(val, allow_collection=False):
         `protobuf` `Value` `Message` representing `val`.
 
     """
+    # TODO: check `allow_collection` before `to_builtin()` to avoid unnecessary processing
+    val = to_builtin(val)
+
     if val is None:
         return Value(null_value=NULL_VALUE)
     elif isinstance(val, bool):  # did you know that `bool` is a subclass of `int`?

--- a/verta/verta/integrations/keras/__init__.py
+++ b/verta/verta/integrations/keras/__init__.py
@@ -39,7 +39,7 @@ class VertaCallback(keras.callbacks.Callback):
         if isinstance(params, dict):
             for key, val in _six.viewitems(params):
                 try:
-                    self.run.log_hyperparameter(key, _utils.to_builtin(val))
+                    self.run.log_hyperparameter(key, val)
                 except:
                     pass  # don't halt execution
 
@@ -84,7 +84,7 @@ class VertaCallback(keras.callbacks.Callback):
         if isinstance(logs, dict):
             for key, val in _six.viewitems(logs):
                 try:
-                    self.run.log_observation(key, _utils.to_builtin(val))
+                    self.run.log_observation(key, val)
                 except:
                     pass  # don't halt execution
 

--- a/verta/verta/integrations/keras/__init__.py
+++ b/verta/verta/integrations/keras/__init__.py
@@ -15,6 +15,9 @@ class VertaCallback(keras.callbacks.Callback):
     """
     Keras callback that automates logging to Verta during model training.
 
+    This callback logs details about the network topology, training hyperparameters, and loss
+    and accuracy during fitting.
+
     .. versionadded:: 0.13.20
 
     Parameters

--- a/verta/verta/integrations/tensorflow/__init__.py
+++ b/verta/verta/integrations/tensorflow/__init__.py
@@ -31,7 +31,9 @@ class VertaHook(SessionRunHook):
     """
     TensorFlow Estimator hook that automates logging to Verta during model training.
 
-    This hook is verified to work with the TensorFlow 1.X API.
+    This hook logs loss during training.
+
+    This hook has been verified to work with the TensorFlow 1.X API.
 
     .. versionadded:: 0.13.20
 

--- a/verta/verta/integrations/xgboost/__init__.py
+++ b/verta/verta/integrations/xgboost/__init__.py
@@ -11,6 +11,8 @@ def verta_callback(run):
     """
     XGBoost callback that automates logging to Verta during booster training.
 
+    This callback logs ``eval_metric``\ s passed into ``xgb.train()``.
+
     .. versionadded:: 0.13.20
 
     Parameters


### PR DESCRIPTION
In the spirit of stronger framework integration and a smoother user experience: `log_metric()`, `log_hyperparameter()`, etc. will coerce arguments to built-in Python types.

Before, logging `np.array(3)` or `torch.tensor(3)` would result in a `TypeError`.  
Now, a user in PyTorch can type
```python
run.log_metric("loss", loss)
```
instead of
```python
run.log_metric("loss", loss.tolist())
```